### PR TITLE
issue #51 : Remove proprietary API

### DIFF
--- a/grails-app/services/au/org/ala/images/ImageService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageService.groovy
@@ -4,13 +4,13 @@ import au.com.bytecode.opencsv.CSVWriter
 import au.org.ala.images.metadata.MetadataExtractor
 import au.org.ala.images.thumb.ThumbnailingResult
 import au.org.ala.images.tiling.TileFormat
-import com.sun.javafx.iio.ImageMetadata
 import grails.converters.JSON
 import grails.transaction.NotTransactional
 import grails.transaction.Transactional
 import groovy.sql.Sql
 import org.apache.commons.codec.binary.Base64
 import org.apache.commons.imaging.Imaging
+import org.apache.commons.imaging.common.ImageMetadata
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata
 import org.apache.commons.imaging.formats.tiff.TiffField
 import org.apache.commons.imaging.formats.tiff.constants.TiffConstants


### PR DESCRIPTION
A proprietary API was introduced in this otherwise unrelated commit in September 2018:

https://github.com/AtlasOfLivingAustralia/image-service/commit/60093ef1dc0973b93c9b4c7c30a55d174394da44#diff-f7b6547f437aa9b4c1c950736acdbe43R7

This commit reverts that part of the commit

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>