### PR TITLE
Batch upload alternative

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 plugins {
     id "com.gorylenko.gradle-git-properties" version "1.4.17"
+    id "org.flywaydb.flyway" version "4.2.0"
 }
 
 
@@ -73,6 +74,7 @@ dependencies {
     compile group: 'au.org.ala.plugins.grails', name:'images-client-plugin', version: '1.1', changing: true
 
     // Added dependencies
+    compile 'org.grails.plugins:postgresql-extensions:5.3.0'
     compile 'org.grails.plugins:cache-headers:2.0.2'
     compile 'org.grails.plugins:external-config:1.2.2'
     compile 'org.grails.plugins:quartz:2.0.13'
@@ -157,6 +159,15 @@ tasks.withType(Test) {
     systemProperty "webdriver.gecko.driver", System.getProperty('webdriver.gecko.driver')
 }
 
+// You can use this plugin to run flyway commands (ie repair) via gradle.
+// To run migrate you will need to define the placeholders
+// Set the url/user/password via gradle properties file, env variables or CLI arguments, eg:
+// ./gradlew -Pflyway.user=myUsr -Pflyway.schemas=schema1,schema2 -Pflyway.placeholders.keyABC=valXYZ
+flyway {
+    url = project.ext.has('flyway.url') ? project.ext['flyway.url'] : 'jdbc:postgresql:images'
+    user = project.ext.has('flyway.user') ? project.ext['flyway.user'] : 'images'
+    password = project.ext.has('flyway.password') ? project.ext['flyway.password'] : 'images'
+}
 
 springBoot {
     buildInfo()

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -8,6 +8,12 @@ grails:
     codegen:
         defaultPackage: au.org.ala.images
     gorm:
+        default:
+            mapping:
+                id:
+                    generator: 'org.hibernate.id.enhanced.SequenceStyleGenerator'
+                    params:
+                    - prefer_sequence_per_entity: false
         reactor:
             # Whether to translate GORM events into Reactor events
             # Disabled by default for performance reasons
@@ -94,7 +100,7 @@ flyway:
     outOfOrder: false
 ---
 hibernate:
-    dialect: org.hibernate.dialect.PostgreSQLDialect
+    dialect: net.kaleidos.hibernate.PostgresqlExtensionsDialect
     cache:
         queries: true
         use_second_level_cache: false
@@ -180,7 +186,7 @@ environments:
 #            exportDir: '/home/travis/build/AtlasOfLivingAustralia/image-service/temp-exports'
     production:
         hibernate:
-            dialect: org.hibernate.dialect.PostgreSQLDialect
+            dialect: net.kaleidos.hibernate.PostgresqlExtensionsDialect
         dataSource:
             dbCreate: validate
             driverClassName: org.postgresql.Driver

--- a/grails-app/controllers/au/org/ala/images/ImageController.groovy
+++ b/grails-app/controllers/au/org/ala/images/ImageController.groovy
@@ -256,12 +256,6 @@ class ImageController {
             return
         }
 
-        // if the image is a duplicate, redirect to original because we
-        // dont store a duplicate copy
-        if (imageInstance.isDuplicateOf){
-            imageInstance = imageInstance.isDuplicateOf;
-        }
-
         boolean contentDisposition = params.boolean("contentDisposition", false)
         boolean cacheHeaders = grailsApplication.config.getProperty('images.cache.headers', Boolean, true)
 

--- a/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
@@ -111,11 +111,6 @@ class ElasticSearchService {
             return
         }
 
-        if (image.isDuplicateOf){
-            log.debug("Supplied image is duplicate. Will not index")
-            return
-        }
-
         def ct = new CodeTimer("Index Image ${image.id}")
         // only add the fields that are searchable. They are marked with an annotation
         def fields = Image.class.declaredFields

--- a/grails-app/services/au/org/ala/images/ImageService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageService.groovy
@@ -94,10 +94,10 @@ class ImageService {
     ImageStoreResult storeImageFromUrl(String imageUrl, String uploader, Map metadata = [:]) {
         if (imageUrl) {
             try {
-                def image = Image.findByOriginalFilename(imageUrl)
+                def image = Image.byOriginalFileOrAlternateFilename(imageUrl) // findByOriginalFilename(imageUrl)
                 if (image && image.stored()) {
                     scheduleMetadataUpdate(image.imageIdentifier, metadata)
-                    return new ImageStoreResult(image, true, image.isDuplicateOf != null)
+                    return new ImageStoreResult(image, true, image.alternateFilename.contains(imageUrl))
                 }
                 def url = new URL(imageUrl)
                 def bytes = url.bytes
@@ -196,7 +196,7 @@ class ImageService {
                         // For filenames (non URLs), use the filename and dataResourceUid to unique identify
                         if (!image){
                             if (imageUrl.startsWith("http")){
-                                image = Image.findByOriginalFilename(imageUrl)
+                                image = Image.byOriginalFileOrAlternateFilename(imageUrl) // findByOriginalFilename(imageUrl)
                             } else {
                                 image = Image.findByOriginalFilenameAndDataResourceUid(imageUrl, imageSource.dataResourceUid)
                             }
@@ -294,7 +294,7 @@ class ImageService {
             // For filenames (non URLs), use the filename and dataResourceUid to unique identify
             if (!image){
                 if (imageUrl.startsWith("http")){
-                    image = Image.findByOriginalFilename(imageUrl)
+                    image = Image.byOriginalFileOrAlternateFilename(imageUrl) // findByOriginalFilename(imageUrl)
                 } else {
                     image = Image.findByOriginalFilenameAndDataResourceUid(imageUrl, imageSource.dataResourceUid)
                 }
@@ -355,7 +355,7 @@ class ImageService {
                      image: image,
                      alreadyStored: true,
                      metadataUpdated: metadataUpdated,
-                     isDuplicate: image.isDuplicateOf != null
+                     isDuplicate: image.alternateFilename.contains(imageUrl)
                 ]
             }
         }  else {
@@ -435,7 +435,7 @@ class ImageService {
             def md5Hash = MD5CodecExtensionMethods.encodeAsMD5(bytes)
 
             //check for existing image using MD5 hash
-            def image = Image.findByContentMD5HashAndIsDuplicateOfIsNull(md5Hash)
+            def image = Image.findByContentMD5Hash(md5Hash)
             def preExisting = false
             def isDuplicate = false
             if (!image) {
@@ -456,7 +456,7 @@ class ImageService {
                         storageLocation: sl
                 )
 
-                if (metadata.extension){
+                if (metadata.extension) {
                     image.extension = metadata.extension
                 } else {
                     // this is known to be problematic
@@ -483,35 +483,25 @@ class ImageService {
                 preExisting = true
             } else if (createDuplicates && image.originalFilename != originalFilename) {
                 log.warn("Existing image found at different URL ${image.originalFilename} to ${originalFilename}. Will add duplicate.")
+                log.warn("Deleted Image has been re-uploaded.  Will undelete.")
+
+                image.dateDeleted = null //reset date deleted if image resubmitted...
+                log.warn("Image moved at source from ${image.originalFilename} to ${originalFilename}. Will add alternate identifier.")
+
                 // we have seen this image before, but the URL has changed at source
                 // so lets update it so that subsequent loads dont need
                 // to re-download this image
-                Image duplicate = new Image()
-                setMetadataOnImage(metadata, duplicate)
-                duplicate.contentMD5Hash = image.contentMD5Hash
-                duplicate.imageIdentifier = UUID.randomUUID().toString() //share ID or new one
-                duplicate.contentSHA1Hash = image.contentSHA1Hash
-                duplicate.uploader = uploaderId
-                duplicate.storageLocation = image.storageLocation
-                duplicate.extension = image.extension
-                duplicate.height = image.height
-                duplicate.width = image.width
-                duplicate.fileSize = image.fileSize
-                duplicate.mimeType = image.mimeType
-                duplicate.dateUploaded = new Date()
-                duplicate.originalFilename = originalFilename
-                duplicate.dateTaken = image.dateTaken
-                duplicate.isDuplicateOf = image
-                duplicate.originalFilename = originalFilename
-                duplicate.save()
-                isDuplicate = true
+                if (!image.alternateFilename.contains(originalFilename)) {
+                    image.alternateFilename += originalFilename
+                }
                 preExisting = true
+                isDuplicate = true
             } else {
                 log.warn("Got a pre-existing image to store {} but it already exists at {}", originalFilename, image.imageIdentifier)
                 preExisting = true
             }
 
-            if (!preExisting){
+            if (!preExisting) {
                 //update metadata stored in the `image` table
                 setMetadataOnImage(metadata, image)
                 //try to match licence
@@ -1304,9 +1294,6 @@ class ImageService {
         }
         results.dataResourceUid = image.dataResourceUid ?: ''
         results.occurrenceID = image.occurrenceId ?: ''
-        if (image.isDuplicateOf){
-            results.isDuplicateOf = image.isDuplicateOf.imageIdentifier
-        }
 
         if (collectoryService) {
             collectoryService.addMetadataForResource(results)

--- a/grails-app/views/image/details.gsp
+++ b/grails-app/views/image/details.gsp
@@ -124,16 +124,6 @@
                                         <td class="property-value">${imageInstance.storageLocation}</td>
                                     </tr>
                                     </auth:ifAnyGranted>
-                                    <g:if test="${imageInstance.isDuplicateOf}">
-                                        <tr>
-                                            <td class="property-name">Duplicate of</td>
-                                            <td class="property-value">
-                                                <g:link controller="image" action="details" id="${imageInstance.isDuplicateOf.imageIdentifier}">
-                                                    ${imageInstance.isDuplicateOf.imageIdentifier}
-                                                </g:link>
-                                            </td>
-                                        </tr>
-                                    </g:if>
                                 </table>
 
                                 <div class="metadataSource-container"></div>
@@ -204,12 +194,7 @@
 
 
             <g:if test="${imageInstance.mimeType.startsWith('image')}">
-              <g:if test="${imageInstance.isDuplicateOf}">
-                imgvwr.viewImage($("#viewerContainerId"), '${imageInstance.isDuplicateOf.imageIdentifier}', "", "", options);
-              </g:if>
-              <g:else>
                 imgvwr.viewImage($("#viewerContainerId"), '${imageInstance.imageIdentifier}', "", "", options);
-              </g:else>
             </g:if>
             <g:elseif test="${imageInstance.mimeType.startsWith('audio')}">
             $('#viewerContainerId .document-icon').css('background-image', 'url("<img:imageThumbUrl imageId='${imageInstance.imageIdentifier}'/>")');

--- a/src/integration-test/groovy/au/org/ala/images/BatchUploadSpec.groovy
+++ b/src/integration-test/groovy/au/org/ala/images/BatchUploadSpec.groovy
@@ -228,14 +228,14 @@ class BatchUploadSpec extends Specification {
 
         // One duplicate created per additional image
         originalImage != null
-        originalImage.isDuplicateOf == null
+//        originalImage.isDuplicateOf == null
         originalImage.mimeType == 'image/png'
         originalImage.dateDeleted == null
         originalImage.audience == 'audience'
         originalImage.zoomLevels > 0 // Indicates that the tiler ran
 
         firstDuplicate != null
-        firstDuplicate.isDuplicateOf == originalImage
+//        firstDuplicate.isDuplicateOf == originalImage
         firstDuplicate.contentMD5Hash == originalImage.contentMD5Hash
         firstDuplicate.mimeType == 'image/png'
         firstDuplicate.dateDeleted == null
@@ -243,7 +243,7 @@ class BatchUploadSpec extends Specification {
         firstDuplicate.zoomLevels == 0 // Duplicate image, so no tiler should have run
 
         secondDuplicate != null
-        secondDuplicate.isDuplicateOf == originalImage
+//        secondDuplicate.isDuplicateOf == originalImage
         secondDuplicate.contentMD5Hash == originalImage.contentMD5Hash
         secondDuplicate.mimeType == 'image/png'
         secondDuplicate.dateDeleted == null

--- a/src/integration-test/groovy/au/org/ala/images/BatchUploadSpec.groovy
+++ b/src/integration-test/groovy/au/org/ala/images/BatchUploadSpec.groovy
@@ -14,6 +14,7 @@ import static au.org.ala.images.AvroUtils.AUDIENCE
 import static au.org.ala.images.AvroUtils.CREATED
 import static au.org.ala.images.AvroUtils.CREATOR
 import static au.org.ala.images.AvroUtils.IDENTIFIER
+import static au.org.ala.images.AvroUtils.IDENTIFIER
 
 @Integration(applicationClass = Application.class)
 @Rollback
@@ -217,9 +218,6 @@ class BatchUploadSpec extends Specification {
         def upload = findBatchFileUpload(response.batchID, start)
 
         def originalImage = findImage(imageUrls[0][0][(IDENTIFIER)], true, start)
-        def firstDuplicate = findImage(imageUrls[1][0][(IDENTIFIER)], false, start)
-        def secondDuplicate = findImage(imageUrls[2][0][(IDENTIFIER)], false, start)
-        originalImage.refresh()
 
         then:
         checkCommonResponse(uploadResponse, response, imageUrls, TEST_DR_UID)
@@ -228,27 +226,45 @@ class BatchUploadSpec extends Specification {
 
         // One duplicate created per additional image
         originalImage != null
-//        originalImage.isDuplicateOf == null
         originalImage.mimeType == 'image/png'
         originalImage.dateDeleted == null
         originalImage.audience == 'audience'
         originalImage.zoomLevels > 0 // Indicates that the tiler ran
+        originalImage.alternateFilename != null
+        originalImage.alternateFilename.size() == 2
+        originalImage.alternateFilename as Set == [imageUrls[1][0][(IDENTIFIER)], imageUrls[2][0][(IDENTIFIER)]] as Set
 
-        firstDuplicate != null
-//        firstDuplicate.isDuplicateOf == originalImage
-        firstDuplicate.contentMD5Hash == originalImage.contentMD5Hash
-        firstDuplicate.mimeType == 'image/png'
-        firstDuplicate.dateDeleted == null
-        firstDuplicate.audience == 'audience2'
-        firstDuplicate.zoomLevels == 0 // Duplicate image, so no tiler should have run
+        when: "uploading a duplicate image again, the duplicate is detected before it is downloaded again"
 
-        secondDuplicate != null
-//        secondDuplicate.isDuplicateOf == originalImage
-        secondDuplicate.contentMD5Hash == originalImage.contentMD5Hash
-        secondDuplicate.mimeType == 'image/png'
-        secondDuplicate.dateDeleted == null
-        secondDuplicate.audience == 'audience3'
-        secondDuplicate.zoomLevels == 0 // Duplicate image, so no tiler should have run
+        uploadResponse = rest.post("${baseUrl}/batch/upload") {
+            contentType "multipart/form-data"
+            setProperty "dataResourceUid", TEST_DR_UID
+            setProperty "archive", avro
+        }
+
+        response = new JsonSlurper().parseText(uploadResponse.body)
+
+        // wait for batch files and images to be created
+        start = System.currentTimeSeconds()
+        // Poll until the image tiler has run on the last image in the batch upload
+        upload = findBatchFileUpload(response.batchID, start)
+
+        originalImage = findImage(imageUrls[0][0][(IDENTIFIER)], true, start)
+
+        then:
+        checkCommonResponse(uploadResponse, response, imageUrls, TEST_DR_UID)
+
+        checkBatchFileUpload(upload, TEST_DR_UID, 3)
+
+        // One duplicate created per additional image
+        originalImage != null
+        originalImage.mimeType == 'image/png'
+        originalImage.dateDeleted == null
+        originalImage.audience == 'audience'
+        originalImage.zoomLevels > 0 // Indicates that the tiler ran
+        originalImage.alternateFilename != null
+        originalImage.alternateFilename.size() == 2 // Check the number of alternate filenames has not increased.
+        originalImage.alternateFilename as Set == [imageUrls[1][0][(IDENTIFIER)], imageUrls[2][0][(IDENTIFIER)]] as Set
 
     }
 

--- a/src/main/resources/db/migration/V202105031529340710__alternate-filenames.sql
+++ b/src/main/resources/db/migration/V202105031529340710__alternate-filenames.sql
@@ -1,0 +1,6 @@
+ALTER TABLE image
+    ADD COLUMN IF NOT EXISTS alternate_filename varchar[],
+    DROP COLUMN IF EXISTS is_duplicate_of_id;
+
+CREATE INDEX image_alternate_filename_idx ON image (alternate_filename);
+


### PR DESCRIPTION
@djtfmartin this is an alternative implementation of the duplicate image URL tracking - I was looking to prevent a chain of duplicates from being possible in the model (ie A.isDuplicateOf = B, B.isDuplicateOf = C).  At the present this shouldn't happen from the code but the model does technically allow it.

The change from this method would be that the new image metadata (audience, creator, etc) would no longer be captured against the duplicate URL.  I'm not sure how desirable that is, so happy for this to go either way.