### PR TITLE
Send valid Access-Control-Allow-Origin headers

### DIFF
--- a/grails-app/controllers/au/org/ala/images/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/images/AdminController.groovy
@@ -298,7 +298,6 @@ class AdminController {
                 render(results as XML)
             }
         }
-        response.addHeader("Access-Control-Allow-Origin", "")
         response.status = responseCode
     }
 

--- a/grails-app/controllers/au/org/ala/images/ImageController.groovy
+++ b/grails-app/controllers/au/org/ala/images/ImageController.groovy
@@ -563,7 +563,6 @@ class ImageController {
                 getOriginalFile()
             }
             json {
-                response.addHeader("Access-Control-Allow-Origin", "")
                 def imageInstance = imageService.getImageFromParams(params)
                 if (imageInstance) {
                     def payload = [:]
@@ -573,6 +572,7 @@ class ImageController {
                         response.setContentType("text/javascript")
                         render("${params.callback}(${jsonStr})")
                     } else {
+                        response.addHeader("Access-Control-Allow-Origin", "*")
                         response.setContentType("application/json")
                         render(jsonStr)
                     }
@@ -582,7 +582,7 @@ class ImageController {
                 }
             }
             xml {
-                response.addHeader("Access-Control-Allow-Origin", "")
+                response.addHeader("Access-Control-Allow-Origin", "*")
                 def imageInstance = imageService.getImageFromParams(params)
                 if(imageInstance) {
                     render(imageInstance as XML)
@@ -723,7 +723,6 @@ class ImageController {
                 render(results as XML)
             }
         }
-        response.addHeader("Access-Control-Allow-Origin", "")
         response.status = responseCode
     }
 


### PR DESCRIPTION
Relates to #130.  Removes Access-Control-Allow-Origin header from end points that require API keys or authentication and sends `Access-Control-Allow-Origin: *` for non-authenticated GET requests.  Proper CORS support can be delayed until after the next release.