### PR TITLE
Added ala-admin to uriFilterPattern

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -198,6 +198,8 @@ security:
             - '/admin/*'
             - '/admin'
             - '/admin/'
+            - '/alaAdmin'
+            - '/alaAdmin/*'
             - '/image/deleteImage/*'
             - '/storageLocation'
             - '/storageLocation/*'


### PR DESCRIPTION
It just add the `alaAdmin` to  `uriFilterPattern` so we don't get the 403 error.