### PR TITLE
Add ingest from S3 bucket support

### DIFF
--- a/src/main/groovy/au/org/ala/images/S3ByteSource.groovy
+++ b/src/main/groovy/au/org/ala/images/S3ByteSource.groovy
@@ -1,0 +1,62 @@
+package au.org.ala.images
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.google.common.io.ByteSource
+
+/**
+ * Accepts a URL in the form s3://bucketname/key and returns a ByteSource for the object in the bucket with the given key.
+ *
+ * Authentication is supported by providing the access key and secret key in the userInfo part of the URL in the form accessKey:secretKey
+ * or by the default AWS credentials provider chain if no userinfo is provided.
+ *
+ * This is not intended to be used with image service managed objects but for ingesting images from S3.
+ */
+class S3ByteSource extends ByteSource {
+
+    private URI url
+
+    S3ByteSource(URI url) {
+        if (url.scheme != 's3') {
+            throw new IllegalArgumentException("URL scheme must be 's3' for S3ByteSource")
+        }
+        if (!url.path) {
+            throw new IllegalArgumentException("URL path is required for S3ByteSource")
+        }
+        if (!url.host) {
+            throw new IllegalArgumentException("URL host is required for S3ByteSource")
+        }
+        if (url.userInfo && !url.userInfo.contains(':')) {
+            throw new IllegalArgumentException("URL userInfo must be in the form 'accessKey:secretKey'")
+        }
+        this.url = url
+    }
+
+    @Override
+    InputStream openStream() throws IOException {
+        def client
+        if (url.userInfo) {
+            def parts = url.userInfo.split(':')
+            client = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(parts[0], parts[1]))).build()
+        } else {
+            client = AmazonS3ClientBuilder.standard().build()
+        }
+
+        def bucketname = url.host
+        def key = url.path
+
+//        if (url.host.matches('s3\\.(.*\\.)?amazonaws\\.com')) {
+//            bucketname = url.path.substring(1, url.path.indexOf('/', 1))
+//            key = url.path.substring(url.path.indexOf('/', 1) + 1)
+//        } else {
+//            bucketname = url.host.substring(0, url.host.indexOf('.'))
+//            key = url.path.substring(1)
+//        }
+//        def path = url.path
+//        if (path.startsWith('/')) {
+//            path = path.substring(1)
+//        }
+        return client.getObject(bucketname, key).getObjectContent()
+    }
+}

--- a/src/main/java/au/org/ala/images/S3URLConnection.java
+++ b/src/main/java/au/org/ala/images/S3URLConnection.java
@@ -6,6 +6,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.logging.log4j.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,10 +15,23 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.regex.Pattern;
 
+/**
+ * Support for non standard s3:// URLs, the URL should be in the form
+ * s3://accesskey:secretKey@bucketname/path
+ *
+ * The accesskey and secretKey are optional, if not provided the default credentials will be used.
+ */
 public class S3URLConnection extends URLConnection {
 
+    private static final Logger log = LoggerFactory.getLogger(S3URLConnection.class);
+
     private S3Object object;
+
+    private String endpoint;
+
+    private boolean pathStyleAccessEnabled = false;
 
     /**
      * Constructs a URL connection to the specified URL. A connection to
@@ -26,6 +41,29 @@ public class S3URLConnection extends URLConnection {
      */
     protected S3URLConnection(URL url) {
         super(url);
+
+        if (!url.getProtocol().equals("s3")) {
+            throw new IllegalArgumentException("URL must use s3 protocol");
+        }
+
+        if (Strings.isBlank(url.getHost())) {
+            throw new IllegalArgumentException("URL must have a bucket name");
+        }
+
+        // TODO support path based.
+        //https://bucket-name.s3.region-code.amazonaws.com/key-name
+        var host = url.getHost();
+        if (!host.matches("(.*)\\.s3\\.(.*\\.)?amazonaws\\.com")) {
+            throw new IllegalArgumentException("URL host must be in the form bucketname.s3.region-code.amazonaws.com");
+        }
+
+        if (Strings.isBlank(url.getPath())) {
+            throw new IllegalArgumentException("URL must have a key");
+        }
+
+        if (url.getUserInfo() != null && url.getUserInfo().split(":").length != 2) {
+            throw new IllegalArgumentException("URL user info must be in the form accesskey:secretKey");
+        }
     }
 
     @Override
@@ -36,20 +74,49 @@ public class S3URLConnection extends URLConnection {
         try {
             uri = url.toURI();
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            throw new IOException(e);
         }
 
+        var host = uri.getHost();
+        var pattern = Pattern.compile("(.*)\\.s3\\.(.*\\.)?amazonaws\\.com");
+
+        var matcher = pattern.matcher(host);
+        String bucket = Strings.EMPTY;
+        String region = Strings.EMPTY;
+        if (matcher.find()) {
+            var groupCount = matcher.groupCount();
+            bucket = matcher.group(1);
+            region = matcher.group(2);
+        }
+        if (!host.matches("(.*)\\.s3\\.(.*\\.)?amazonaws\\.com")) {
+            throw new IllegalArgumentException("URL host must be in the form bucketname.s3.region-code.amazonaws.com");
+        }
+
+        var builder = AmazonS3ClientBuilder.standard();
         if (Strings.isNotBlank(uri.getUserInfo())) {
             var parts = uri.getUserInfo().split(":");
-            client = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(parts[0], parts[1]))).build();
-        } else {
-            client = AmazonS3ClientBuilder.standard().build();
+            builder = builder.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(parts[0], parts[1])));
+        }
+        if (Strings.isNotBlank(region)) {
+            if (Strings.isNotBlank(endpoint)) {
+                builder = builder.withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(endpoint, region));
+            } else {
+                builder = builder.withRegion(region);
+            }
+        }
+        if (pathStyleAccessEnabled) {
+            builder = builder.withPathStyleAccessEnabled(true);
+        }
+        client = builder.build();
+
+
+        var key = uri.getPath();
+        if (key.startsWith("/")) {
+            key = key.substring(1);
         }
 
-        var bucketname = uri.getHost();
-        var key = uri.getPath();
-
-        object = client.getObject(bucketname, key);
+        log.trace("Connecting to s3 bucket: {} key: {}", bucket, key);
+        object = client.getObject(bucket, key);
 
 //        if (url.host.matches('s3\\.(.*\\.)?amazonaws\\.com')) {
 //            bucketname = url.path.substring(1, url.path.indexOf('/', 1))
@@ -58,45 +125,93 @@ public class S3URLConnection extends URLConnection {
 //            bucketname = url.host.substring(0, url.host.indexOf('.'))
 //            key = url.path.substring(1)
 //        }
-//        def path = url.path
-//        if (path.startsWith('/')) {
-//            path = path.substring(1)
-//        }
-//        return client.getObject(bucketname, key).getObjectContent()
+
+    }
+
+    public void disconnect() {
+        if (object != null) {
+            try {
+                object.close();
+            } catch (IOException e) { /* ignored */ }
+            object = null;
+        }
+    }
+
+    private void ensureConnected() {
+        if (object == null) {
+            try {
+                connect();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @Override
     public String getContentEncoding() {
+        ensureConnected();
         return object.getObjectMetadata().getContentEncoding();
     }
 
     @Override
     public long getContentLengthLong() {
+        ensureConnected();
         return object.getObjectMetadata().getContentLength();
     }
 
     @Override
     public String getContentType() {
+        ensureConnected();
         return object.getObjectMetadata().getContentType();
     }
 
     @Override
     public long getExpiration() {
+        ensureConnected();
         return object.getObjectMetadata().getExpirationTime().getTime();
     }
 
     @Override
     public long getLastModified() {
+        ensureConnected();
         return object.getObjectMetadata().getLastModified().getTime();
     }
 
     @Override
     public InputStream getInputStream() throws IOException {
+        ensureConnected();
         return object.getObjectContent();
     }
 
     @Override
     public String getHeaderField(String name) {
+        ensureConnected();
         return object.getObjectMetadata().getRawMetadataValue(name).toString();
+    }
+
+    /**
+     * For testing, allows overriding the default amazon s3 endpoint
+     *
+     * @return the endpoint
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * For testing, allows overriding the default amazon s3 endpoint
+     *
+     * @param endpoint the new endpoint to use, eg localstack.local
+     */
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public boolean isPathStyleAccessEnabled() {
+        return pathStyleAccessEnabled;
+    }
+
+    public void setPathStyleAccessEnabled(boolean pathStyleAccessEnabled) {
+        this.pathStyleAccessEnabled = pathStyleAccessEnabled;
     }
 }

--- a/src/main/java/au/org/ala/images/S3URLConnection.java
+++ b/src/main/java/au/org/ala/images/S3URLConnection.java
@@ -1,0 +1,102 @@
+package au.org.ala.images;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import org.apache.logging.log4j.util.Strings;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class S3URLConnection extends URLConnection {
+
+    private S3Object object;
+
+    /**
+     * Constructs a URL connection to the specified URL. A connection to
+     * the object referenced by the URL is not created.
+     *
+     * @param url the specified URL.
+     */
+    protected S3URLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public void connect() throws IOException {
+        AmazonS3 client;
+        URI uri;
+
+        try {
+            uri = url.toURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (Strings.isNotBlank(uri.getUserInfo())) {
+            var parts = uri.getUserInfo().split(":");
+            client = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(parts[0], parts[1]))).build();
+        } else {
+            client = AmazonS3ClientBuilder.standard().build();
+        }
+
+        var bucketname = uri.getHost();
+        var key = uri.getPath();
+
+        object = client.getObject(bucketname, key);
+
+//        if (url.host.matches('s3\\.(.*\\.)?amazonaws\\.com')) {
+//            bucketname = url.path.substring(1, url.path.indexOf('/', 1))
+//            key = url.path.substring(url.path.indexOf('/', 1) + 1)
+//        } else {
+//            bucketname = url.host.substring(0, url.host.indexOf('.'))
+//            key = url.path.substring(1)
+//        }
+//        def path = url.path
+//        if (path.startsWith('/')) {
+//            path = path.substring(1)
+//        }
+//        return client.getObject(bucketname, key).getObjectContent()
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return object.getObjectMetadata().getContentEncoding();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return object.getObjectMetadata().getContentLength();
+    }
+
+    @Override
+    public String getContentType() {
+        return object.getObjectMetadata().getContentType();
+    }
+
+    @Override
+    public long getExpiration() {
+        return object.getObjectMetadata().getExpirationTime().getTime();
+    }
+
+    @Override
+    public long getLastModified() {
+        return object.getObjectMetadata().getLastModified().getTime();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return object.getObjectContent();
+    }
+
+    @Override
+    public String getHeaderField(String name) {
+        return object.getObjectMetadata().getRawMetadataValue(name).toString();
+    }
+}

--- a/src/main/java/au/org/ala/images/S3URLStreamHandler.java
+++ b/src/main/java/au/org/ala/images/S3URLStreamHandler.java
@@ -1,0 +1,14 @@
+package au.org.ala.images;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+public class S3URLStreamHandler extends URLStreamHandler {
+
+    @Override
+    protected URLConnection openConnection(URL u) throws IOException {
+        return new S3URLConnection(u);
+    }
+}

--- a/src/main/java/au/org/ala/images/S3URLStreamHandler.java
+++ b/src/main/java/au/org/ala/images/S3URLStreamHandler.java
@@ -5,6 +5,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
+/**
+ * Support s3:// URLs
+ */
 public class S3URLStreamHandler extends URLStreamHandler {
 
     @Override

--- a/src/main/java/au/org/ala/images/S3URLStreamHandlerProvider.java
+++ b/src/main/java/au/org/ala/images/S3URLStreamHandlerProvider.java
@@ -3,6 +3,9 @@ package au.org.ala.images;
 import java.net.URLStreamHandler;
 import java.net.spi.URLStreamHandlerProvider;
 
+/**
+ * Support s3:// URLs
+ */
 public class S3URLStreamHandlerProvider extends URLStreamHandlerProvider {
 
     @Override

--- a/src/main/java/au/org/ala/images/S3URLStreamHandlerProvider.java
+++ b/src/main/java/au/org/ala/images/S3URLStreamHandlerProvider.java
@@ -1,0 +1,15 @@
+package au.org.ala.images;
+
+import java.net.URLStreamHandler;
+import java.net.spi.URLStreamHandlerProvider;
+
+public class S3URLStreamHandlerProvider extends URLStreamHandlerProvider {
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        if ("s3".equals(protocol)) {
+            return new S3URLStreamHandler();
+        }
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
+++ b/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
@@ -1,0 +1,1 @@
+au.org.ala.images.S3URLStreamHandlerProvider

--- a/src/test/groovy/au/org/ala/images/S3URLConnectionSpec.groovy
+++ b/src/test/groovy/au/org/ala/images/S3URLConnectionSpec.groovy
@@ -1,0 +1,89 @@
+package au.org.ala.images
+
+import cloud.localstack.Constants
+import cloud.localstack.Localstack
+import cloud.localstack.ServiceName
+import cloud.localstack.docker.LocalstackDockerExtension
+import cloud.localstack.docker.annotation.LocalstackDockerProperties
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.junit.jupiter.api.extension.ExtendWith
+import spock.lang.Specification
+
+
+@ExtendWith(LocalstackDockerExtension.class)
+@LocalstackDockerProperties(services = [ ServiceName.S3 ], imageTag = '4.1.1')
+class S3URLConnectionSpec extends Specification {
+
+    def setupSpec() {
+
+        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard().
+                withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(Localstack.INSTANCE.endpointS3, Constants.DEFAULT_REGION)).
+                withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(Constants.TEST_ACCESS_KEY, Constants.TEST_SECRET_KEY))).
+                withClientConfiguration(
+                        new ClientConfiguration()
+                                .withValidateAfterInactivityMillis(200))
+        builder.setPathStyleAccessEnabled(true)
+        AmazonS3 clientS3 = builder.build()
+        clientS3.createBucket('example')
+        clientS3.putObject('example', 'key', 'content')
+        clientS3.getObject('example', 'key')
+
+        def localstack = Localstack.INSTANCE
+
+    }
+
+    def "should throw an exception if the URL scheme is not 's3'"() {
+        given:
+        def url = new URI("http://example.com").toURL()
+
+        when:
+        new S3URLConnection(url)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "should throw an exception if the URL path is missing"() {
+        given:
+        def url = new URI("s3://example.s3.region.amazonaws.com").toURL()
+
+        when:
+        new S3URLConnection(url)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "should throw an exception if the URL host is missing"() {
+        given:
+        def url = new URI("s3:///key").toURL()
+
+        when:
+        new S3URLConnection(url)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "should return the content of the object in the bucket with the given key"() {
+        given:
+
+        def userinfo = "${Constants.TEST_ACCESS_KEY}:${Constants.TEST_SECRET_KEY}"
+        def url = new URI("s3://${userinfo}@example.s3.${Constants.DEFAULT_REGION}.amazonaws.com/key").toURL()
+
+        when:
+        def connection = new S3URLConnection(url)
+        connection.setEndpoint(Localstack.INSTANCE.endpointS3)
+        connection.setPathStyleAccessEnabled(true)
+        def content = connection.getInputStream().text
+
+        then:
+        content == "content"
+    }
+
+}


### PR DESCRIPTION
Add support for S3 to support when uploading images via URLs for #183 .

In this PR it supports URLs in the form `s3://<accesskey>:<secret>@<bucket>.s3.<region>.amazonaws.com/<key>`.  Providing a userinfo, ie `accesskey` and `secret`, is optional.  In this case, it will fall back to the default permissions, so access to the bucket could be controlled via AWS EC2 IAM roles, etc.