### PR TITLE
4.0 SNAPSHOT Updates

### DIFF
--- a/grails-app/services/au/org/ala/images/ImageService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageService.groovy
@@ -329,31 +329,6 @@ UNION
         return byteSource
     }
 
-    static class CloseableByteSource extends ByteSource implements AutoCloseable {
-        private File file
-
-        @Delegate
-        private ByteSource delegate
-
-        CloseableByteSource(File file) {
-            this.file = file
-            this.delegate = Files.asByteSource(file)
-        }
-
-        CloseableByteSource(byte [] bytes) {
-            this.delegate = ByteSource.wrap(bytes)
-        }
-
-        @Override
-        void close() throws Exception {
-            if (file) {
-                if (!file.delete()) {
-                    log.warn("Failed to delete temporary file: {}", file)
-                }
-            }
-        }
-    }
-
     def getImageUrl(Map<String, String> imageSource){
         if (imageSource.sourceUrl) return imageSource.sourceUrl
         if (imageSource.imageUrl) return imageSource.imageUrl

--- a/grails-app/services/au/org/ala/images/ImageStoreService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageStoreService.groovy
@@ -139,7 +139,7 @@ class ImageStoreService {
             log.trace('Storing image {} with content type {}, original filename {}, content disposition {} to {}', uuid, contentType, originalFilename, contentDisposition, operations)
         }
         def imgDesc = new ImageDescriptor(imageIdentifier: uuid)
-        operations.store(uuid, imageBytes.openStream(), contentType, contentDisposition)
+        operations.store(uuid, imageBytes.openStream(), contentType, contentDisposition, imageBytes.sizeIfKnown().orNull())
         def filename = ImageUtils.getFilename(originalFilename)
         if (contentType?.toLowerCase()?.startsWith('image')) {
             if (log.isTraceEnabled()) {

--- a/src/main/groovy/au/org/ala/images/ClosableByteSource.groovy
+++ b/src/main/groovy/au/org/ala/images/ClosableByteSource.groovy
@@ -1,0 +1,41 @@
+package au.org.ala.images
+
+import com.google.common.io.ByteSource
+import com.google.common.io.Files
+import com.google.common.base.Optional
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class CloseableByteSource extends ByteSource implements AutoCloseable {
+    private File file
+
+    @Delegate
+    private ByteSource delegate
+
+    CloseableByteSource(File file) {
+        this.file = file
+        this.delegate = Files.asByteSource(file)
+    }
+
+    CloseableByteSource(byte [] bytes) {
+        this.delegate = ByteSource.wrap(bytes)
+    }
+
+    Optional<Long> sizeIfKnown() {
+        return delegate.sizeIfKnown()
+    }
+
+    @Override
+    long size() throws IOException {
+        return delegate.size()
+    }
+
+    @Override
+    void close() throws Exception {
+        if (file) {
+            if (!file.delete()) {
+                log.warn("Failed to delete temporary file: {}", file)
+            }
+        }
+    }
+}

--- a/src/main/groovy/au/org/ala/images/DeletedImagesPurgeBackgroundTask.groovy
+++ b/src/main/groovy/au/org/ala/images/DeletedImagesPurgeBackgroundTask.groovy
@@ -16,4 +16,9 @@ class DeletedImagesPurgeBackgroundTask extends BackgroundTask {
     void execute() {
         imageService.purgeAllDeletedImages()
     }
+
+    @Override
+    boolean isRequiresSession() {
+        return true
+    }
 }

--- a/src/main/groovy/au/org/ala/images/ImageMetadataUpdateBackgroundTask.groovy
+++ b/src/main/groovy/au/org/ala/images/ImageMetadataUpdateBackgroundTask.groovy
@@ -19,6 +19,11 @@ class ImageMetadataUpdateBackgroundTask extends BackgroundTask {
     }
 
     @Override
+    boolean isRequiresSession() {
+        return true
+    }
+
+    @Override
     String toString() {
         return "ImageMetadataUpdateBackgroundTask," + _imageIdentifier
     }

--- a/src/main/groovy/au/org/ala/images/IndexImageBackgroundTask.groovy
+++ b/src/main/groovy/au/org/ala/images/IndexImageBackgroundTask.groovy
@@ -21,7 +21,7 @@ class IndexImageBackgroundTask extends BackgroundTask {
     void execute() {
         def imageInstance
         Image.withTransaction {
-            imageInstance = Image.get(_imageId)
+            imageInstance = Image.findById(_imageId, [fetch: [recognisedLicense: 'eager']])
         }
         if (imageInstance) {
             _elasticSearchService.indexImage(imageInstance)

--- a/src/main/groovy/au/org/ala/images/ScheduleLicenseReMatchAllBackgroundTask.groovy
+++ b/src/main/groovy/au/org/ala/images/ScheduleLicenseReMatchAllBackgroundTask.groovy
@@ -3,7 +3,6 @@ package au.org.ala.images
 class ScheduleLicenseReMatchAllBackgroundTask extends BackgroundTask {
 
     private ImageService _imageService
-    boolean requiresSession = true
 
     ScheduleLicenseReMatchAllBackgroundTask(ImageService imageService) {
         _imageService = imageService
@@ -12,5 +11,10 @@ class ScheduleLicenseReMatchAllBackgroundTask extends BackgroundTask {
     @Override
     void execute() {
         _imageService.updateLicences()
+    }
+
+    @Override
+    boolean isRequiresSession() {
+        return true
     }
 }

--- a/src/main/groovy/au/org/ala/images/ScheduleMissingImagesBackgroundTask.groovy
+++ b/src/main/groovy/au/org/ala/images/ScheduleMissingImagesBackgroundTask.groovy
@@ -56,4 +56,9 @@ class ScheduleMissingImagesBackgroundTask extends BackgroundTask {
         writer.close()
         log.info("Missing images check complete. Total checked: " + counter)
     }
+
+    @Override
+    boolean isRequiresSession() {
+        return true
+    }
 }

--- a/src/main/groovy/au/org/ala/images/storage/StorageOperations.groovy
+++ b/src/main/groovy/au/org/ala/images/storage/StorageOperations.groovy
@@ -37,7 +37,7 @@ interface StorageOperations {
      * @param contentDisposition The content disposition if any
      */
     default void store(String uuid, byte[] bytes, String contentType = 'image/jpeg', String contentDisposition = null) {
-        store(uuid, new ByteArrayInputStream(bytes), contentType, contentDisposition, bytes.length)
+        store(uuid, new ByteArrayInputStream(bytes), contentType, contentDisposition, Long.valueOf(bytes.length))
     }
 
     /**


### PR DESCRIPTION
 - Update various BackgroundTasks to override requireSession so that a session is actually provided when required
 - Update IndexImageBackgroundTask to eagerly fetch license metdata to prevent Hibernate proxy error
 - Update ClosableByteSource to delegate size methods
 - Update ImageStoreService to pass the length parameter to the storage operation