### PR TITLE
Update S3StorageOperations to not set a canned ACL

### DIFF
--- a/grails-app/controllers/au/org/ala/images/StorageLocationController.groovy
+++ b/grails-app/controllers/au/org/ala/images/StorageLocationController.groovy
@@ -66,7 +66,8 @@ class StorageLocationController {
         boolean updateAcls = false
 
         if (instance instanceof S3StorageLocation) {
-            updateAcls = instance.isDirty('publicRead')
+            // Trigger ACL refresh if either publicRead or privateAcl changed
+            updateAcls = instance.isDirty('publicRead') || instance.isDirty('privateAcl')
         }
 
         instance.save()

--- a/grails-app/domain/au/org/ala/images/S3StorageLocation.groovy
+++ b/grails-app/domain/au/org/ala/images/S3StorageLocation.groovy
@@ -37,6 +37,10 @@ class S3StorageLocation extends StorageLocation {
     String secretKey
     boolean containerCredentials
     boolean publicRead
+    // When true, explicitly request S3 canned Private ACL on upload/updates.
+    // When false (and publicRead is also false), no ACL header is added and
+    // bucket defaults/policies apply.
+    boolean privateAcl
     boolean redirect
     String cloudfrontDomain
 
@@ -66,6 +70,7 @@ class S3StorageLocation extends StorageLocation {
                 secretKey: secretKey,
                 containerCredentials: containerCredentials,
                 publicRead: publicRead,
+                privateAcl: privateAcl,
                 redirect: redirect,
                 pathStyleAccess: pathStyleAccess,
                 hostname: hostname,

--- a/grails-app/init/au/org/ala/images/Application.groovy
+++ b/grails-app/init/au/org/ala/images/Application.groovy
@@ -2,9 +2,18 @@ package au.org.ala.images
 
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
+import org.springframework.context.annotation.Bean
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
         GrailsApp.run(Application, args)
+    }
+
+    @Bean
+    ExecutorService analyticsExecutor() {
+        return Executors.newSingleThreadExecutor()
     }
 }

--- a/grails-app/init/au/org/ala/images/BootStrap.groovy
+++ b/grails-app/init/au/org/ala/images/BootStrap.groovy
@@ -36,6 +36,7 @@ class BootStrap {
                 secretKey: it.secretKey ?: '',
                 containerCredentials: it.containerCredentials ?: false,
                 publicRead: it.publicRead ?: false,
+                privateAcl: it.privateAcl ?: false,
                 redirect: it.redirect ?: false,
                 cloudfrontDomain: it.cloudfrontDomain ?: '',
             ]

--- a/grails-app/views/admin/storageLocations.gsp
+++ b/grails-app/views/admin/storageLocations.gsp
@@ -82,6 +82,15 @@
                                 </div>
                                 <div class="checkbox">
                                     <label>
+                                        <input type="checkbox" id="privateAcl" name="privateAcl"> Explicit Private ACL
+                                    </label>
+                                    <p class="help-block">
+                                        If checked (and Public read is not), uploaded objects get S3 canned "private" ACL.
+                                        If both unchecked, no ACL header is sent and bucket defaults apply.
+                                    </p>
+                                </div>
+                                <div class="checkbox">
+                                    <label>
                                         <input type="checkbox" id="redirect" name="redirect"> Redirect
                                     </label>
                                 </div>

--- a/grails-app/views/storageLocation/editFragment.gsp
+++ b/grails-app/views/storageLocation/editFragment.gsp
@@ -55,6 +55,19 @@
                 <label>
                     <g:checkBox name="publicRead" value="${s3StorageLocation.publicRead}" /> Public read
                 </label>
+                <p class="help-block">
+                    When checked (and Private ACL is not), uploaded objects will be set to S3 "public read" via canned ACL.
+                    When both are unchecked, no ACL header is sent and bucket defaults apply.
+                </p>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <g:checkBox name="privateAcl" value="${s3StorageLocation.privateAcl}" /> Explicit Private ACL
+                </label>
+                <p class="help-block">
+                    When checked (and Public read is not), uploaded objects will be set to S3 "private" via canned ACL.
+                    When both are unchecked, no ACL header is sent and bucket defaults apply.
+                </p>
             </div>
             <div class="checkbox">
                 <label>

--- a/src/main/resources/db/migration/V202511271615000000__s3_storage_private_acl.sql
+++ b/src/main/resources/db/migration/V202511271615000000__s3_storage_private_acl.sql
@@ -1,0 +1,11 @@
+-- Add explicit private_acl flag for S3 storage locations
+-- Allows UI to request S3 Canned Private ACL explicitly; when false and publicRead is false,
+-- we avoid sending any ACL header so bucket defaults apply.
+
+ALTER TABLE storage_location
+  ADD COLUMN IF NOT EXISTS private_acl BOOLEAN;
+
+-- Default existing rows to false for S3 storage locations where null
+UPDATE storage_location
+  SET private_acl = NOT public_read
+  WHERE class = 'au.org.ala.images.S3StorageLocation' AND private_acl IS NULL;

--- a/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
+++ b/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
@@ -1,0 +1,142 @@
+package au.org.ala.images
+
+import au.org.ala.images.storage.S3StorageOperations
+import au.org.ala.web.AuthService
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.CopyObjectRequest
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import grails.testing.gorm.DataTest
+import grails.web.mapping.LinkGenerator
+import groovy.util.logging.Slf4j
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import spock.lang.Specification
+
+@Slf4j
+class S3StorageOperationsSpec extends Specification implements DataTest {
+
+    def setupSpec() {
+        mockDomains(Image, StorageLocation, S3StorageLocation)
+    }
+
+    private static class TestOps extends S3StorageOperations {
+        AmazonS3 mockClient
+        @Override
+        protected AmazonS3 getS3Client() { return mockClient }
+    }
+
+    def "store uses PublicRead ACL and public cache when publicRead=true"() {
+        given:
+        def client = Mock(AmazonS3)
+        def ops = new TestOps(bucket: 'b', publicRead: true, privateAcl: false, mockClient: client)
+
+        when:
+        ops.store('uuid-1', new ByteArrayInputStream('x'.bytes), 'image/jpeg', null, 123)
+
+        then:
+        1 * client.putObject({ it.metadata.contentType == 'image/jpeg' &&
+            it.metadata.contentLength == 123 &&
+            it.metadata.rawMetadata['x-amz-acl'] == CannedAccessControlList.PublicRead.toString() &&
+            it.metadata.cacheControl == 'public,s-maxage=31536000,max-age=31536000' })
+    }
+
+    def "store uses Private ACL and private cache when privateAcl=true and publicRead=false"() {
+        given:
+        def client = Mock(AmazonS3)
+        def ops = new TestOps(bucket: 'b', publicRead: false, privateAcl: true, mockClient: client)
+
+        when:
+        ops.store('uuid-2', new ByteArrayInputStream('y'.bytes), 'image/png', 'inline', 10)
+
+        then:
+        1 * client.putObject({ it.metadata.contentDisposition == 'inline' &&
+            it.metadata.rawMetadata['x-amz-acl'] == CannedAccessControlList.Private.toString() &&
+            it.metadata.cacheControl == 'private,max-age=31536000' })
+    }
+
+    def "store leaves ACL and cache-control unset when both flags are false"() {
+        given:
+        def client = Mock(AmazonS3)
+        def ops = new TestOps(bucket: 'b', publicRead: false, privateAcl: false, mockClient: client)
+
+        when:
+        ops.store('uuid-3', new ByteArrayInputStream('z'.bytes), 'image/gif', null, null)
+
+        then:
+        1 * client.putObject({ !it.metadata.rawMetadata.containsKey('x-amz-acl') && it.metadata.cacheControl == null })
+    }
+
+    def "updateACL sets PublicRead and public cache-control when publicRead=true"() {
+        given:
+        def client = Mock(AmazonS3)
+        def obj = new S3ObjectSummary(bucketName: 'b', key: 'k')
+        def md = new ObjectMetadata()
+        def ops = new TestOps(bucket: 'b', prefix: '', publicRead: true, privateAcl: false, mockClient: client)
+
+        when:
+        ops.updateACL()
+
+        then:
+        1 * client.listObjects('b', '') >> { args ->
+            new ObjectListing().tap {
+                objectSummaries.addAll([obj])
+                truncated = false
+            }
+        }
+
+        1 * client.setObjectAcl('b', 'k', CannedAccessControlList.PublicRead)
+        1 * client.getObjectMetadata('b', 'k') >> md
+        1 * client.copyObject({ CopyObjectRequest cor ->
+            cor.destinationBucketName == 'b' && cor.destinationKey == 'k' &&
+                cor.newObjectMetadata.cacheControl == 'public,s-maxage=31536000,max-age=31536000'
+        })
+    }
+
+    def "updateACL sets Private and private cache-control when privateAcl=true and publicRead=false"() {
+        given:
+        def client = Mock(AmazonS3)
+        def obj = new S3ObjectSummary(bucketName: 'b', key: 'k')
+        def md = new ObjectMetadata()
+        def ops = new TestOps(bucket: 'b', prefix: '', publicRead: false, privateAcl: true, mockClient: client)
+
+        when:
+        ops.updateACL()
+
+        then:
+        1 * client.listObjects('b', '') >> { args ->
+            new ObjectListing().tap {
+                objectSummaries.addAll([obj])
+                truncated = false
+            }
+        }
+        1 * client.setObjectAcl('b', 'k', CannedAccessControlList.Private)
+        1 * client.getObjectMetadata('b', 'k') >> md
+        1 * client.copyObject({ CopyObjectRequest cor ->
+            cor.newObjectMetadata.cacheControl == 'private,max-age=31536000'
+        })
+    }
+
+    def "updateACL does not change ACL and removes cache-control when neither flag is set"() {
+        given:
+        def client = Mock(AmazonS3)
+        def obj = new S3ObjectSummary(bucketName: 'b', key: 'k')
+        def md = new ObjectMetadata()
+        def ops = new TestOps(bucket: 'b', prefix: '', publicRead: false, privateAcl: false, mockClient: client)
+
+        when:
+        ops.updateACL()
+
+        then:
+        1 * client.listObjects('b', '') >> { args ->
+            new ObjectListing().tap {
+                objectSummaries.addAll([obj])
+                truncated = false
+            }
+        }
+        0 * client.setObjectAcl(_, _, _)
+        1 * client.getObjectMetadata('b', 'k') >> md
+        1 * client.copyObject({ CopyObjectRequest cor -> cor.newObjectMetadata.cacheControl == null })
+    }
+}

--- a/src/test/groovy/au/org/ala/images/StorageLocationServiceFlybernateSpec.groovy
+++ b/src/test/groovy/au/org/ala/images/StorageLocationServiceFlybernateSpec.groovy
@@ -2,8 +2,17 @@ package au.org.ala.images
 
 import au.org.ala.images.helper.FlybernateSpec
 import grails.testing.services.ServiceUnitTest
+import org.grails.spring.beans.factory.InstanceFactoryBean
+
+import java.util.concurrent.Executor
 
 class StorageLocationServiceFlybernateSpec extends FlybernateSpec implements ServiceUnitTest<StorageLocationService> {
+
+    def setup() {
+        defineBeans {
+            analyticsExecutor(InstanceFactoryBean, [execute: { Runnable r -> r.run() } ] as Executor, Executor)
+        }
+    }
 
     // GORM Unit testing returns an ArrayList for Criteria.scroll {}, so we run
     // this test against a real database

--- a/src/test/groovy/au/org/ala/images/StorageLocationServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/images/StorageLocationServiceSpec.groovy
@@ -1,15 +1,31 @@
 package au.org.ala.images
 
+import com.amazonaws.services.s3.model.ObjectListing
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
+import grails.web.mapping.LinkGenerator
+import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.javaswift.joss.client.factory.AuthenticationMethod
 import spock.lang.Specification
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3ObjectSummary
+
+import java.util.concurrent.Executor
 
 class StorageLocationServiceSpec extends Specification implements ServiceUnitTest<StorageLocationService>, DataTest {
 
 
     def setupSpec() {
         mockDomains StorageLocation, FileSystemStorageLocation, S3StorageLocation, SwiftStorageLocation, Image
+    }
+
+
+    def setup() {
+        defineBeans {
+            analyticsExecutor(InstanceFactoryBean, [ execute: { Runnable r -> r.run() } ] as Executor, Executor)
+        }
     }
 
     def "test createStorageLocation"() {
@@ -38,7 +54,8 @@ class StorageLocationServiceSpec extends Specification implements ServiceUnitTes
                 prefix: '/some/prefix',
                 accessKey: 'asdfasdf',
                 secretKey: 'asdfasdf',
-                publicRead: false
+                publicRead: false,
+                privateAcl: true
         ]
 
         def s3sl = service.createStorageLocation(json)
@@ -51,6 +68,7 @@ class StorageLocationServiceSpec extends Specification implements ServiceUnitTes
         s3sl.accessKey == 'asdfasdf'
         s3sl.secretKey == 'asdfasdf'
         s3sl.publicRead == false
+        s3sl.privateAcl == true
 
         when: "creating a duplicate S3 Storage Location"
         def s3sl2 = service.createStorageLocation(json)
@@ -96,6 +114,71 @@ class StorageLocationServiceSpec extends Specification implements ServiceUnitTes
 
         then: "The storage location is rejected"
         thrown RuntimeException
+    }
+
+    def "updateAcl executes when enabled and below threshold and performs S3 ACL+copy operations"() {
+        given:
+        // domain mocks
+        def s3 = new S3StorageLocation(region: 'r', bucket: 'b', prefix: '', privateAcl: true, publicRead: false)
+        s3.save(validate: false)
+        new Image(storageLocation: s3).save(validate: false)
+
+        // Replace executor with synchronous stub via getter metaclass
+        boolean executed = false
+        def spyExecutor = [ execute: { Runnable r -> executed = true } ] as java.util.concurrent.Executor
+        service.analyticsExecutor = spyExecutor
+
+        // enable and set threshold higher than count
+        service.updateAclEnabled = true
+        service.updateAclObjectThreshold = 5
+
+        when:
+        service.updateAcl(s3)
+
+        then:
+        executed
+    }
+
+    def "updateAcl skips when enabled but object count meets or exceeds threshold"() {
+        given:
+        def s3 = new S3StorageLocation(region: 'r', bucket: 'b', prefix: '')
+        s3.save(validate: false)
+        // create 3 images for this storage location
+        3.times { new Image(storageLocation: s3).save(validate: false) }
+
+        boolean executed = false
+        // executor spy that would set flag if invoked
+        def spyExecutor = [ execute: { Runnable r -> executed = true } ] as java.util.concurrent.Executor
+        service.analyticsExecutor = spyExecutor
+
+        service.updateAclEnabled = true
+        service.updateAclObjectThreshold = 2 // less than the 3 images
+
+        when:
+        service.updateAcl(s3)
+
+        then:
+        executed == false
+    }
+
+    def "updateAcl skips entirely when feature disabled"() {
+        given:
+        def s3 = new S3StorageLocation(region: 'r', bucket: 'b', prefix: '')
+        s3.save(validate: false)
+        new Image(storageLocation: s3).save(validate: false)
+
+        boolean executed = false
+        def spyExecutor = [ execute: { Runnable r -> executed = true } ] as java.util.concurrent.Executor
+        service.analyticsExecutor = spyExecutor
+
+        service.updateAclEnabled = false
+        service.updateAclObjectThreshold = 1000
+
+        when:
+        service.updateAcl(s3)
+
+        then:
+        executed == false
     }
 
 }


### PR DESCRIPTION
This is required to enable no public read setting on the S3 Bucket and allow Bucket wide ACLs to be used.