### PR TITLE
Fix for 'query did not return a unique result' errors

### DIFF
--- a/grails-app/domain/au/org/ala/images/Image.groovy
+++ b/grails-app/domain/au/org/ala/images/Image.groovy
@@ -213,11 +213,15 @@ class Image implements AsyncEntity<Image> {
     }
 
     static Image byOriginalFileOrAlternateFilename(String filename) {
+        // this should be unique for more recent images but may not be for older images
+        // so we just return the latest match
         Image.withCriteria(uniqueResult: true) {
             or {
                 eq 'originalFilename', filename
                 pgArrayContains 'alternateFilename', filename
             }
+            maxResults(1)
+            order("dateUploaded", "desc") // get the most recent one if multiple exist
         }
     }
 }


### PR DESCRIPTION
This fixes an issue whereby older Image records might have more than one record with the same original_filename as the data model doesn't explicitly disallow it.  In these cases, just present the most recent upload as the duplicate image.