### PR TITLE
Fix for pathological batch upload race condition

### DIFF
--- a/src/main/groovy/au/org/ala/images/ImageStoreResult.groovy
+++ b/src/main/groovy/au/org/ala/images/ImageStoreResult.groovy
@@ -11,4 +11,16 @@ class ImageStoreResult {
         this.image = image
         this.isDuplicate = isDuplicate;
     }
+
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ImageStoreResult{")
+        sb.append("image.id=").append(image.id)
+        sb.append(", image.imageIdentifier=").append(image.imageIdentifier)
+        sb.append(", alreadyStored=").append(alreadyStored)
+        sb.append(", isDuplicate=").append(isDuplicate)
+        sb.append('}')
+        return sb.toString()
+    }
 }


### PR DESCRIPTION
- Add pre-lock step to determine imageIdentifier to lock on, if any
- Fail before locking if the URL given is a failed url
- Lock on imageIdentifier instead of URL if an identifier can be found
- Fixes batch uploads that are sending a number of images that are alternate URLs for the same image