### PR TITLE
Introduce JSONB field alternative to ImageMetaDataItem table

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     // Added dependencies
     runtimeOnly 'com.zaxxer:HikariCP:5.1.0'
     implementation 'org.grails.plugins:postgresql-extensions:7.0.0'
+//    implementation 'io.github.gpc:grails-postgresql-extensions:8.0.0'
     implementation "org.flywaydb:flyway-core:9.4.0"
     implementation 'org.grails.plugins:cache-headers:2.0.2'
     runtimeOnly 'org.codehaus.groovy:groovy-dateutil'
@@ -88,7 +89,7 @@ dependencies {
     // TEMP: Keep AWS SDK v1 during migration; remove once all code/tests are v2
 //    implementation "com.amazonaws:aws-java-sdk-s3:1.12.418"
     implementation 'org.javaswift:joss:0.10.4'
-    runtimeOnly 'org.postgresql:postgresql:42.7.4'
+    runtimeOnly 'org.postgresql:postgresql:42.7.8'
 
     implementation 'co.elastic.clients:elasticsearch-java:7.17.29'
     implementation 'org.elasticsearch.client:elasticsearch-rest-client:7.17.29'
@@ -96,6 +97,7 @@ dependencies {
 
     implementation 'org.imgscalr:imgscalr-lib:4.2'
     implementation 'org.apache.commons:commons-imaging:1.0.0-alpha5'
+//    implementation platform('org.apache.tika:tika-bom:3.2.3') // TODO need to keep this in sync with image-utils
     implementation 'org.apache.tika:tika-core:3.2.3' // TODO need to keep this in sync with image-utils
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'com.github.jai-imageio:jai-imageio-core:1.4.0'
@@ -124,6 +126,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'io.micrometer:micrometer-registry-statsd'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Standard grails
     implementation("org.grails:grails-core")

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -151,6 +151,7 @@ flyway:
 hibernate:
     allow_update_outside_transaction: true # Hibernate 5 made transactions required to flush changes, set to true for backwards compat but should be set to false and bugs fixed in the future
     show_sql: false
+#    dialect: gpc.pgext.hibernate.PostgresqlExtensionsDialect
     dialect: net.kaleidos.hibernate.PostgresqlExtensionsDialect
     cache:
         queries: true
@@ -257,6 +258,7 @@ environments:
         batchUpload: '${RUNNER_TEMP}/temp-uploads'
     production:
         hibernate:
+#            dialect: gpc.pgext.hibernate.PostgresqlExtensionsDialect
             dialect: net.kaleidos.hibernate.PostgresqlExtensionsDialect
         dataSource:
             dbCreate: validate
@@ -688,6 +690,18 @@ images:
       avifenc:
         cmd: "avifenc"
         inPlace: false
+  metadata:
+    legacy:
+      persist:
+        enabled: true
+    jsonb:
+      migration:
+        enabled: true
+        batchSize: 100
+        maxBatchesPerRun: 10
+        startTime: '23:00'
+        endTime: '06:00'
+        maxLoadAverage: 6.0 # tune this for your system, eg 6 might be too high for a small ec2 instance
 
 # External links
 collectory:

--- a/grails-app/controllers/au/org/ala/images/ImageController.groovy
+++ b/grails-app/controllers/au/org/ala/images/ImageController.groovy
@@ -798,19 +798,22 @@ class ImageController implements MetricsSupport {
         def metaData = []
         def source = null
         if (imageInstance) {
+            // Use helper method that reads from JSONB with fallback to EAV table
+            def allMetadata = imageService.getImageMetadata(imageInstance)
+
             if (params.source) {
                 source = MetaDataSourceType.valueOf(params.source)
                 if (source){
-                    metaData = imageInstance.metadata?.findAll { it.source == source }
+                    metaData = allMetadata?.findAll { it.source == source }
                 } else {
-                    metaData = imageInstance.metadata
+                    metaData = allMetadata
                 }
             } else {
-                metaData = imageInstance.metadata
+                metaData = allMetadata
             }
         }
 
-        [imageInstance: imageInstance, metaData: metaData?.sort { it.name }, source: source]
+        [imageInstance: imageInstance, metaData: metaData?.sort { it.key }, source: source]
     }
 
     def coreImageMetadataTableFragment() {
@@ -834,7 +837,7 @@ class ImageController implements MetricsSupport {
 
     def createSubimageFragment() {
         def imageInstance = imageService.getImageFromParams(params)
-        def metadata = ImageMetaDataItem.findAllByImage(imageInstance)
+        def metadata = imageService.getImageMetadata(imageInstance)
         [imageInstance: imageInstance, x: params.x, y: params.y, width: params.width, height: params.height, metadata: metadata]
     }
 

--- a/grails-app/controllers/au/org/ala/images/SearchController.groovy
+++ b/grails-app/controllers/au/org/ala/images/SearchController.groovy
@@ -25,7 +25,7 @@ class SearchController {
 
     def list() {
 
-        def ct = new CodeTimer("Image list")
+        def ct = new CodeTimer("Image list").tap { debug() }
 
         params.offset = params.offset ?: 0
         params.max = params.max ?: 50

--- a/grails-app/controllers/au/org/ala/images/WebServiceController.groovy
+++ b/grails-app/controllers/au/org/ala/images/WebServiceController.groovy
@@ -1407,8 +1407,8 @@ class WebServiceController implements MetricsSupport {
 
     @Operation(
             method = "GET",
-            summary = "Get Metadata",
-            description = "Get Metadata.",
+            summary = "Get Metadata field names",
+            description = "Get Metadata field names known to this service.",
             parameters = [
                     @Parameter(name = "source", in = QUERY, required = false, description = "Only return metadata items with this source", schema = @Schema(implementation = MetaDataSourceType)),
             ],
@@ -1421,32 +1421,17 @@ class WebServiceController implements MetricsSupport {
                             ])],
             tags = ["Image metadata"]
     )
-    @Path("/ws/getMetadataKeys")
+    @Path("/ws/metadatakeys")
     @Consumes("application/json")
     @Produces("application/json")
     def getMetadataKeys() {
 
         def source = params.source as MetaDataSourceType
-        def results
-        def c = ImageMetaDataItem.createCriteria()
 
-        if (source) {
-            results = c.list {
-                eq("source", source)
-                projections {
-                    distinct("name")
-                }
-            }
+        // Use ImageService method that queries both JSONB (migrated) and EAV (unmigrated) images
+        def results = imageService.getDistinctMetadataKeys(source)
 
-        } else {
-            results = c.list {
-                projections {
-                    distinct("name")
-                }
-            }
-        }
-
-        renderResults(results?.sort { it?.toLowerCase() }, 200, true)
+        renderResults(results, 200, true)
     }
 
     @Operation(

--- a/grails-app/jobs/au/org/ala/images/MetadataJsonMigrationJob.groovy
+++ b/grails-app/jobs/au/org/ala/images/MetadataJsonMigrationJob.groovy
@@ -1,0 +1,200 @@
+package au.org.ala.images
+
+import grails.core.GrailsApplication
+import grails.gorm.transactions.Transactional
+import groovy.util.logging.Slf4j
+
+import java.lang.management.ManagementFactory
+import java.time.LocalTime
+
+/**
+ * Quartz job to migrate metadata from EAV table (image_meta_data_item) to JSONB column (metadata).
+ * Runs during low-usage hours (configurable) to avoid impacting production workload.
+ * Uses batching and pagination to handle large datasets without overwhelming the database.
+ */
+@Slf4j
+class MetadataJsonMigrationJob {
+
+    def imageService
+    GrailsApplication grailsApplication
+
+    static concurrent = false
+
+    static triggers = {
+        // Run every minute to check if we should migrate
+        cron name: 'metadataJsonMigrationTrigger', cronExpression: '0 0/1 * * * ?'
+    }
+
+    def execute() {
+        try {
+            // Check if migration is enabled
+            boolean migrationEnabled = grailsApplication.config.getProperty('images.metadata.jsonb.migration.enabled', Boolean, false)
+            if (!migrationEnabled) {
+                log.trace("Metadata JSONB migration is disabled")
+                return
+            }
+
+            // Check if we're in the allowed time window
+            if (!isInMigrationWindow()) {
+                log.trace("Not in migration time window")
+                return
+            }
+
+            // Check system load if configured
+            if (isSystemLoadTooHigh()) {
+                log.debug("System load too high, skipping migration")
+                return
+            }
+
+            int batchSize = grailsApplication.config.getProperty('images.metadata.jsonb.migration.batchSize', Integer, 100)
+            int maxBatchesPerRun = grailsApplication.config.getProperty('images.metadata.jsonb.migration.maxBatchesPerRun', Integer, 10)
+
+            log.info("Starting metadata JSONB migration run (batchSize={}, maxBatches={})", batchSize, maxBatchesPerRun)
+
+            int totalMigrated = 0
+            int batchesProcessed = 0
+
+            while (batchesProcessed < maxBatchesPerRun) {
+                int migrated = migrateBatch(batchSize)
+                totalMigrated += migrated
+                batchesProcessed++
+
+                if (migrated == 0) {
+                    log.info("No more images to migrate")
+                    break
+                }
+
+                // Check if we should stop due to time window or load
+                if (!isInMigrationWindow() || isSystemLoadTooHigh()) {
+                    log.info("Stopping migration: window closed or load too high")
+                    break
+                }
+            }
+
+            if (totalMigrated > 0) {
+                log.info("Metadata JSONB migration run completed: {} images migrated in {} batches", totalMigrated, batchesProcessed)
+            }
+
+        } catch (Exception ex) {
+            log.error("Exception in metadata JSONB migration job", ex)
+        }
+    }
+
+    /**
+     * Migrate a batch of images from EAV to JSONB
+     * @param batchSize Number of images to process
+     * @return Number of images actually migrated
+     */
+    @Transactional
+    int migrateBatch(int batchSize) {
+        // Find images without metadata (null indicates not yet migrated)
+        def images = Image.createCriteria().list(max: batchSize) {
+            isNull('metadata')
+//            isNull('dateDeleted')  // Skip deleted images
+            order('id', 'asc')     // Process in ID order for predictability
+        }
+
+        if (!images) {
+            return 0
+        }
+
+        log.debug("Migrating batch of {} images", images.size())
+
+        int migrated = 0
+        images.each { Image image ->
+            try {
+                migrateImageMetadata(image)
+                migrated++
+            } catch (Exception ex) {
+                log.error("Failed to migrate metadata for image {}: {}", image.id, ex.message, ex)
+                // Mark as migrated with empty map so we don't keep retrying
+                image.metadata = [:]
+                image.save(flush: false)
+            }
+        }
+
+        return migrated
+    }
+
+    /**
+     * Migrate metadata for a single image from EAV to JSONB
+     * @param image The image to migrate
+     */
+    private void migrateImageMetadata(Image image) {
+        def metadataItems = ImageMetaDataItem.findAllByImage(image)
+
+        if (metadataItems) {
+            // Build JSONB map with nested structure: { "key": { "value": "...", "source": "..." } }
+            def jsonMap = [:]
+            metadataItems.each { md ->
+                jsonMap[md.name] = [
+                    value: md.value,
+                    source: md.source.toString()
+                ]
+            }
+            image.metadata = jsonMap
+            log.trace("Migrated {} metadata items for image {}", metadataItems.size(), image.id)
+        } else {
+            // No metadata - set to empty map to mark as processed
+            image.metadata = [:]
+            log.trace("No metadata to migrate for image {}, marking as processed", image.id)
+        }
+
+        image.save(flush: false)
+    }
+
+    /**
+     * Check if current time is within the configured migration window
+     */
+    private boolean isInMigrationWindow() {
+        // Default: 11 PM to 6 AM (low usage hours)
+        String startTime = grailsApplication.config.getProperty('images.metadata.jsonb.migration.startTime', String, '23:00')
+        String endTime = grailsApplication.config.getProperty('images.metadata.jsonb.migration.endTime', String, '06:00')
+
+        try {
+            LocalTime now = LocalTime.now()
+            LocalTime start = LocalTime.parse(startTime)
+            LocalTime end = LocalTime.parse(endTime)
+
+            // Handle overnight window (e.g., 23:00 to 06:00)
+            if (start.isAfter(end)) {
+                return now.isAfter(start) || now.isBefore(end)
+            } else {
+                return now.isAfter(start) && now.isBefore(end)
+            }
+        } catch (Exception ex) {
+            log.warn("Invalid time configuration for migration window: start={}, end={}", startTime, endTime, ex)
+            return false
+        }
+    }
+
+    /**
+     * Check if system load is too high to run migration
+     * Can be extended to check actual system metrics
+     */
+    private boolean isSystemLoadTooHigh() {
+        // Simple implementation - can be enhanced to check actual load average
+        double maxLoadAverage = grailsApplication.config.getProperty('images.metadata.jsonb.migration.maxLoadAverage', Double, 6.0d)
+
+        // disable check if maxLoadAverage <= 0
+        if (maxLoadAverage <= 0.0d) {
+            return false
+        }
+
+        try {
+            def os = ManagementFactory.getOperatingSystemMXBean()
+            if (os.metaClass.respondsTo(os, 'getSystemLoadAverage')) {
+                double load = os.systemLoadAverage
+                if (load > 0 && load > maxLoadAverage) {
+                    log.debug("System load {} exceeds max {}", load, maxLoadAverage)
+                    return true
+                }
+            }
+        } catch (Exception ex) {
+            log.debug("Could not check system load: {}", ex.message)
+        }
+
+        return false
+    }
+}
+

--- a/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
@@ -170,7 +170,7 @@ class ElasticSearchService implements MetricsSupport {
 
             try {
                 log.debug("Indexing image {}", image.id)
-                def ct = new CodeTimer("Index Image ${image.id}")
+                def ct = new CodeTimer("Index Image ${image.id}").tap { debug() }
                 // only add the fields that are searchable. They are marked with an annotation
                 def fields = Image.class.declaredFields
                 def data = [:]
@@ -847,7 +847,7 @@ class ElasticSearchService implements MetricsSupport {
             ct = new CodeTimer("Object retrieval (${searchResponse.hits().hits().size()} of ${searchResponse.hits().total().value()} hits)")
             final hitsIdList = searchResponse.hits() ? searchResponse.hits().hits()*.id() : []
             final imageList = hitsIdList ? Image.findAllByImageIdentifierInList(hitsIdList)?.collect { image ->
-                image.metadata = null
+//                image.metadata = null
                 image.tags = null
                 asMap(image)
             } ?: [] : []

--- a/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/images/ElasticSearchService.groovy
@@ -804,7 +804,7 @@ class ElasticSearchService implements MetricsSupport {
         boolQueryBuilder
     }
 
-    def filtered = ['class', 'active', 'metaClass', 'tags', 'keywords', 'metadata']
+    def filtered = ['class', 'active', 'metaClass', 'tags', 'keywords', 'metadata', 'metadataItems']
 
     Map asMap(Image image) {
 
@@ -847,7 +847,7 @@ class ElasticSearchService implements MetricsSupport {
             ct = new CodeTimer("Object retrieval (${searchResponse.hits().hits().size()} of ${searchResponse.hits().total().value()} hits)")
             final hitsIdList = searchResponse.hits() ? searchResponse.hits().hits()*.id() : []
             final imageList = hitsIdList ? Image.findAllByImageIdentifierInList(hitsIdList)?.collect { image ->
-//                image.metadata = null
+                image.metadataItems = null
                 image.tags = null
                 asMap(image)
             } ?: [] : []

--- a/grails-app/services/au/org/ala/images/ImageService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageService.groovy
@@ -917,6 +917,15 @@ unnest(all_urls) AS unnest_url;
                 //update metadata stored in the `image` table
                 setMetadataOnImage(metadata, image)
 
+                // Store extracted metadata in JSONB column immediately to avoid race condition with optimisation
+                if (imgDesc?.extractedMetadata) {
+                    log.debug("Storing pre-optimisation metadata for image {} with {} keys in JSONB column", image.imageIdentifier, imgDesc.extractedMetadata.size())
+                    image.metadata = convertMetadataToJsonMap(imgDesc.extractedMetadata, MetaDataSourceType.Embedded)
+                } else {
+                    // Mark as processed even if no metadata (empty map vs null indicates migration status)
+                    image.metadata = [:]
+                }
+
                 result = Image.withTransaction {
                     for (storage in defaultStorages) {
                         storage.applyToImage(image)
@@ -928,15 +937,6 @@ unnest(all_urls) AS unnest_url;
                         image = image.save(failOnError: true)
                         log.trace("storeImageBytes: saved new image record ({}:{}) for originalFilename: {}", image.id, image.imageIdentifier, originalFilename)
 
-                        // TODO We need to add a JSONB column to the image table, otherwise we run this in the background task only
-                        // as the size of the metadata items table can be very large and slow down this transaction
-                        // If we have extracted metadata from before optimisation, persist it now
-//                        boolean metadataPersisted = false
-//                        if (imgDesc.extractedMetadata) {
-//                            log.debug("Persisting pre-optimisation metadata for image {} with {} keys", image.id, imgDesc.extractedMetadata.size())
-//                            persistExtractedMetadata(image.id, imgDesc.extractedMetadata, MetaDataSourceType.Embedded)
-//                            metadataPersisted = true
-//                        }
 
                         return new ImageStoreResult(image, preExisting, isDuplicate, false)
                     } catch (Exception ex) {
@@ -988,11 +988,44 @@ unnest(all_urls) AS unnest_url;
         if (!images || !key) {
             return [:]
         }
-        def results = ImageMetaDataItem.executeQuery("select md.value, md.image.id from ImageMetaDataItem md where md.image in (:images) and lower(name) = :key and source=:source", [images: images, key: key.toLowerCase(), source: source])
+
         def fr = [:]
-        results.each {
-            fr[it[1]] = it[0]
+
+        // Try JSONB first for images that have it
+        images.each { image ->
+            if (image.metadata != null) {
+                // Check for key in nested structure: { "key": { "value": "...", "source": "..." } }
+                def metaObj = image.metadata[key]
+                if (metaObj instanceof Map) {
+                    def sourceStr = metaObj.source
+                    // Check if source matches
+                    if (sourceStr == source.toString()) {
+                        fr[image.id] = metaObj.value
+                    }
+                } else if (!metaObj) {
+                    // Try case-insensitive search
+                    def matchingEntry = image.metadata.find { k, v ->
+                        k.equalsIgnoreCase(key) && v instanceof Map && v.source == source.toString()
+                    }
+                    if (matchingEntry?.value instanceof Map) {
+                        fr[image.id] = matchingEntry.value.value
+                    }
+                }
+            }
         }
+
+        // For images not found in JSONB (null metadata), fallback to EAV table
+        def imagesNotInJson = images.findAll { it.metadata == null }
+        if (imagesNotInJson) {
+            def results = ImageMetaDataItem.executeQuery(
+                "select md.value, md.image.id from ImageMetaDataItem md where md.image in (:images) and lower(name) = :key and source=:source",
+                [images: imagesNotInJson, key: key.toLowerCase(), source: source]
+            )
+            results.each {
+                fr[it[1]] = it[0]
+            }
+        }
+
         return fr
     }
 
@@ -1166,7 +1199,13 @@ unnest(all_urls) AS unnest_url;
     }
 
     def scheduleImageMetadataPersist(long imageId, String imageIdentifier, String fileName,  MetaDataSourceType metaDataSourceType, String uploaderId, Map<String, Object> extractedMetadata = null){
-        scheduleBackgroundTask(new ImageMetadataPersistBackgroundTask(imageId, imageIdentifier, fileName, metaDataSourceType, uploaderId, imageService, imageStoreService, extractedMetadata))
+        // Allow disabling background metadata persistence when using JSONB column
+        boolean enableBackgroundPersist = grailsApplication.config.getProperty('images.metadata.legacy.persist.enabled', Boolean, true)
+        if (enableBackgroundPersist) {
+            scheduleBackgroundTask(new ImageMetadataPersistBackgroundTask(imageId, imageIdentifier, fileName, metaDataSourceType, uploaderId, imageService, imageStoreService, extractedMetadata))
+        } else {
+            log.debug("Background metadata persistence disabled by config for image {}", imageId)
+        }
     }
 
     def scheduleBackgroundTask(BackgroundTask task) {
@@ -1531,16 +1570,35 @@ unnest(all_urls) AS unnest_url;
                 return false
             }
 
-            // See if we already have an existing item...
-            def existing = ImageMetaDataItem.findByImageAndNameAndSource(image, key, source)
-            if (existing) {
-                existing.value = value
-                existing.save()
+            // Initialize metadata if null (for existing images)
+            if (image.metadata == null) {
+                image.metadata = [:]
+            }
+
+            // Update JSONB column with nested structure
+            if (value) {
+                image.metadata[key] = [
+                    value: value,
+                    source: source.toString()
+                ]
             } else {
-                if (value){
-                    image.addToMetadata(new ImageMetaDataItem(image: image, name: key, value: value, source: source)).save()
+                image.metadata.remove(key)
+            }
+
+            // Optionally persist to legacy EAV table (for backward compatibility during migration)
+            boolean persistToLegacyTable = grailsApplication.config.getProperty('images.metadata.legacy.persist.enabled', Boolean, true)
+            if (persistToLegacyTable) {
+                def existing = ImageMetaDataItem.findByImageAndNameAndSource(image, key, source)
+                if (existing) {
+                    existing.value = value
+                    existing.save()
+                } else {
+                    if (value){
+                        image.addToMetadataItems(new ImageMetaDataItem(image: image, name: key, value: value, source: source)).save()
+                    }
                 }
             }
+
             return true
         } else {
             log.debug("Not Setting metadata item! Image ${image?.id} key: ${key} value: ${value}")
@@ -1562,6 +1620,15 @@ unnest(all_urls) AS unnest_url;
         if (!userId) {
             userId = "<unknown>"
         }
+
+        // Initialize metadata if null (for existing images)
+        if (image.metadata == null) {
+            image.metadata = [:]
+        }
+
+        // Check if legacy EAV persistence is enabled
+        boolean persistToLegacyTable = grailsApplication.config.getProperty('images.metadata.legacy.persist.enabled', Boolean, true)
+
         metadata.each { kvp ->
             def value = sanitizeString(kvp.value?.toString())
             def key = kvp.key
@@ -1572,16 +1639,23 @@ unnest(all_urls) AS unnest_url;
                     return false
                 }
 
-                // See if we already have an existing item...
-                def existing = ImageMetaDataItem.findByImageAndNameAndSource(image, key, source)
-                if (existing) {
-                    existing.value = value
-                } else {
-//                    log.info("Storing metadata: ${image.title}, name: ${key}, value: ${value}, source: ${source}")
-                    if(key && value) {
-                        def md = new ImageMetaDataItem(image: image, name: key, value: value, source: source)
-                        md.save(failOnError: true)
-                        image.addToMetadata(md)
+                // Update JSONB column with nested structure
+                image.metadata[key] = [
+                    value: value,
+                    source: source.toString()
+                ]
+
+                // Optionally persist to legacy EAV table (for backward compatibility during migration)
+                if (persistToLegacyTable) {
+                    def existing = ImageMetaDataItem.findByImageAndNameAndSource(image, key, source)
+                    if (existing) {
+                        existing.value = value
+                    } else {
+                        if(key && value) {
+                            def md = new ImageMetaDataItem(image: image, name: key, value: value, source: source)
+                            md.save(failOnError: true)
+                            image.addToMetadataItems(md)
+                        }
                     }
                 }
 
@@ -1597,14 +1671,30 @@ unnest(all_urls) AS unnest_url;
     @Transactional
     def removeMetaDataItem(Image image, String key, MetaDataSourceType source, String userId="<unknown>") {
         def count = 0
-        def items = ImageMetaDataItem.findAllByImageAndNameAndSource(image, key, source)
-        if (items) {
-            items.each { md ->
-                count++
-                md.delete()
-            }
-            scheduleImageIndex(image.id)
+
+        // Initialize metadata if null (for existing images)
+        if (image.metadata == null) {
+            image.metadata = [:]
         }
+
+        // Remove from JSONB column
+        image.metadata.remove(key)
+
+        // Check if legacy EAV persistence is enabled
+        boolean persistToLegacyTable = grailsApplication.config.getProperty('images.metadata.legacy.persist.enabled', Boolean, true)
+
+        if (persistToLegacyTable) {
+            def items = ImageMetaDataItem.findAllByImageAndNameAndSource(image, key, source)
+            if (items) {
+                items.each { md ->
+                    count++
+                    md.delete()
+                }
+                scheduleImageIndex(image.id)
+            }
+        }
+
+        image.save()
         auditService.log(image, "Delete metadata item ${key} (${count} items)", userId)
         return count > 0
     }
@@ -1744,32 +1834,22 @@ unnest(all_urls) AS unnest_url;
             return [columnHeaders: ["imageUrl", "occurrenceId"], data: []]
         }
 
-        def c = ImageMetaDataItem.createCriteria()
-        // retrieve just the relevant metadata rows
-        def metaDataRows = c.list {
-            inList("image", images)
-            or {
-                eq("source", MetaDataSourceType.SystemDefined)
-                eq("source", MetaDataSourceType.UserDefined)
-            }
-        }
-
-        def metaDataMappedbyImage = metaDataRows.groupBy {
-            it.image.id
-        }
-
+        // TODO Fix this to not N+1 query when we don't have JSONB metadata
         def columnHeaders = ['imageUrl', 'occurrenceId']
-
         def tabularData = []
 
         images.each { image ->
             def map =  [occurrenceId: image.imageIdentifier, 'imageUrl': imageService.getImageUrl(image.imageIdentifier)]
-            def imageMetadata = metaDataMappedbyImage[image.id]
-            imageMetadata.each { md ->
-                if (md.value) {
-                    map[md.name] = md.value
-                    if (!columnHeaders.contains(md.name)) {
-                        columnHeaders << md.name
+
+            // Get metadata using JSONB or fallback to EAV
+            def metadataList = getImageMetadata(image)
+
+            // Filter to only SystemDefined and UserDefined sources
+            metadataList.each { md ->
+                if (md.value && (md.source == MetaDataSourceType.SystemDefined || md.source == MetaDataSourceType.UserDefined)) {
+                    map[md.key] = md.value
+                    if (!columnHeaders.contains(md.key)) {
+                        columnHeaders << md.key
                     }
                 }
             }
@@ -1938,11 +2018,7 @@ unnest(all_urls) AS unnest_url;
         }
 
         if (includeMetadata) {
-            results.metadata = []
-            def metaDataList = ImageMetaDataItem.findAllByImage(image)
-            metaDataList?.each { md ->
-                results.metadata << [key: md.name, value: md.value, source: md.source]
-            }
+            results.metadata = getImageMetadata(image)
         }
     }
 
@@ -2338,5 +2414,118 @@ unnest(all_urls) AS unnest_url;
         if (source && imageIdentifier && deleteSource) {
             source.deleteStored(imageIdentifier)
         }
+    }
+
+    /**
+     * Convert metadata map to JSONB-compatible format.
+     * Structure: { "key": { "value": "...", "source": "Embedded" } }
+     * @param extractedMetadata Raw metadata map
+     * @param source The metadata source type
+     * @return Map suitable for JSONB storage
+     */
+    private Map convertMetadataToJsonMap(Map<String, Object> extractedMetadata, MetaDataSourceType source) {
+        if (!extractedMetadata) {
+            return [:]
+        }
+
+        def result = [:]
+        extractedMetadata.each { key, value ->
+            def cleanedValue = sanitizeString(value)
+            if (cleanedValue && cleanedValue.length() < 8000) {
+                result[key] = [
+                    value: cleanedValue,
+                    source: source.toString()
+                ]
+            }
+        }
+        return result
+    }
+
+    /**
+     * Get metadata for an image, preferring JSONB column but falling back to EAV table.
+     * Returns list of maps with keys: key, value, source
+     * @param image The image to get metadata for
+     * @return List of metadata items
+     */
+    List<Map> getImageMetadata(Image image) {
+        if (image.metadata != null && !image.metadata.isEmpty()) {
+            // Use JSONB column (new way)
+            // Structure: { "key": { "value": "...", "source": "Embedded" } }
+            def results = []
+            image.metadata.each { key, metaObj ->
+                if (metaObj instanceof Map) {
+                    def value = metaObj.value
+                    def sourceStr = metaObj.source
+                    def source = sourceStr ? MetaDataSourceType.valueOf(sourceStr) : MetaDataSourceType.SystemDefined
+                    results << [key: key, value: value, source: source]
+                } else {
+                    // Fallback for unexpected format
+                    results << [key: key, value: metaObj.toString(), source: MetaDataSourceType.SystemDefined]
+                }
+            }
+            return results
+        } else {
+            // Fallback to EAV table (old way)
+            def results = []
+            def metaDataList = ImageMetaDataItem.findAllByImage(image)
+            metaDataList?.each { md ->
+                results << [key: md.name, value: md.value, source: md.source]
+            }
+            return results
+        }
+    }
+
+    /**
+     * Get all distinct metadata keys across all images, with optional source filtering.
+     * Queries both JSONB column and EAV table for complete coverage.
+     * @param source Optional - filter by metadata source type
+     * @return List of distinct metadata keys
+     */
+    List<String> getDistinctMetadataKeys(MetaDataSourceType source = null) {
+        def keys = [] as Set<String>
+
+        // Get keys from JSONB column (for migrated images)
+        Image.withSession { session ->
+            String sql
+            if (source) {
+                sql = """
+                    SELECT DISTINCT kv.key
+                    FROM image i, jsonb_each(i.metadata) AS kv
+                    WHERE i.metadata IS NOT NULL 
+                      AND i.date_deleted IS NULL
+                      AND kv.value->>'source' = :source
+                """
+            } else {
+                sql = """
+                    SELECT DISTINCT jsonb_object_keys(i.metadata)
+                    FROM image i
+                    WHERE i.metadata IS NOT NULL
+                      AND i.date_deleted IS NULL
+                """
+            }
+
+            def query = session.createSQLQuery(sql)
+            if (source) {
+                query.setParameter("source", source.toString())
+            }
+            def jsonbKeys = query.list()
+            if (jsonbKeys) {
+                keys.addAll(jsonbKeys)
+            }
+        }
+
+        // Get keys from EAV table (for unmigrated images)
+        def eavQuery
+        if (source) {
+            eavQuery = "SELECT DISTINCT md.name FROM ImageMetaDataItem md WHERE md.image.dateDeleted IS NULL AND md.source = :source"
+            def eavKeys = ImageMetaDataItem.executeQuery(eavQuery, [source: source])
+            keys.addAll(eavKeys)
+        } else {
+            eavQuery = "SELECT DISTINCT md.name FROM ImageMetaDataItem md WHERE md.image.dateDeleted IS NULL"
+            def eavKeys = ImageMetaDataItem.executeQuery(eavQuery)
+            keys.addAll(eavKeys)
+        }
+
+        return keys.toList().sort { it?.toLowerCase() }
     }
 }

--- a/grails-app/services/au/org/ala/images/ImageStoreService.groovy
+++ b/grails-app/services/au/org/ala/images/ImageStoreService.groovy
@@ -332,7 +332,7 @@ class ImageStoreService implements MetricsSupport {
                         }
                     }
                 } catch (Throwable t) {
-                    log.warn('Image optimisation failed for {}: {}', uuid, t.message)
+                    log.warn('Image optimisation failed for {}: {}', uuid, t.message, t)
                 }
             }
 
@@ -549,7 +549,7 @@ class ImageStoreService implements MetricsSupport {
 
     private List<ThumbnailingResult> generateThumbnailsImpl(ByteSource byteSource, String imageIdentifier, StorageOperations operations, String type = null) {
         return recordTime('imagestore.thumbnail.generate', 'Time to generate thumbnails', [type: type ?: 'all', count: type == null ? '6' : '1']) {
-            def ct = new CodeTimer("Generating ${type != null ? 1 : 6} thumbnails for image ${imageIdentifier}")
+            def ct = new CodeTimer("Generating ${type != null ? 1 : 6} thumbnails for image ${imageIdentifier}").tap { debug() }
             def t = new ImageThumbnailer()
     //        def imageIdentifier = image.imageIdentifier
             int size = grailsApplication.config.getProperty('imageservice.thumbnail.size') as Integer

--- a/grails-app/taglib/au/org/ala/images/ImagesTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/images/ImagesTagLib.groovy
@@ -368,12 +368,24 @@ class ImagesTagLib {
     }
 
     /**
-     * @attr metaDataItem The metadata item whose value is to be rendered
+     * @attr metaDataItem The metadata item whose value is to be rendered (can be ImageMetaDataItem or Map)
      */
     def renderMetaDataValue = { attrs, body ->
-        ImageMetaDataItem md = attrs.metaDataItem as ImageMetaDataItem
+        def md = attrs.metaDataItem
         if (md) {
-            out << sanitiserService.sanitise(new MetaDataValueFormatRules(grailsApplication).formatValue(md))
+            // Handle both Map format (from JSONB) and ImageMetaDataItem objects (from EAV)
+            def metaDataItem
+            if (md instanceof Map) {
+                // Create a pseudo-ImageMetaDataItem from the map for formatting
+                metaDataItem = new ImageMetaDataItem(
+                    name: md.key,
+                    value: md.value,
+                    source: md.source
+                )
+            } else {
+                metaDataItem = md as ImageMetaDataItem
+            }
+            out << sanitiserService.sanitise(new MetaDataValueFormatRules(grailsApplication).formatValue(metaDataItem))
         }
     }
 

--- a/grails-app/views/image/imageMetadataTableFragment.gsp
+++ b/grails-app/views/image/imageMetadataTableFragment.gsp
@@ -8,8 +8,8 @@
 <g:if test="${metaData}">
     <table class="table table-bordered table-condensed table-striped">
         <g:each in="${metaData}" var="md">
-            <tr metaDataKey="${md.name}">
-                <td class="property-name">${md.name}</td>
+            <tr metaDataKey="${md.key}">
+                <td class="property-name">${md.key}</td>
                 <td class="property-value"><img:renderMetaDataValue metaDataItem="${md}" />
                     <auth:ifAnyGranted roles="${CASRoles.ROLE_ADMIN}">
                         <g:if test="${source == MetaDataSourceType.UserDefined}">

--- a/src/main/groovy/au/org/ala/images/JsonbMapType.groovy
+++ b/src/main/groovy/au/org/ala/images/JsonbMapType.groovy
@@ -1,0 +1,7 @@
+package au.org.ala.images
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class JsonbMapType extends net.kaleidos.hibernate.usertype.JsonbMapType implements Serializable {
+}

--- a/src/main/java/au/org/ala/images/ArrayType.java
+++ b/src/main/java/au/org/ala/images/ArrayType.java
@@ -3,4 +3,5 @@ package au.org.ala.images;
 import java.io.Serializable;
 
 public class ArrayType extends net.kaleidos.hibernate.usertype.ArrayType implements Serializable {
+//public class ArrayType extends gpc.pgext.hibernate.usertype.ArrayType implements Serializable {
 }

--- a/src/main/resources/db/migration/V202512190000000000__add_image_metadata_jsonb.sql
+++ b/src/main/resources/db/migration/V202512190000000000__add_image_metadata_jsonb.sql
@@ -1,0 +1,16 @@
+-- Add JSONB column for metadata to image table
+-- This is part of a zero-downtime migration from the EAV-style image_meta_data_item table
+
+-- Add the new column (nullable for now to allow gradual migration)
+ALTER TABLE image ADD COLUMN IF NOT EXISTS metadata jsonb;
+
+-- Add a GIN index for efficient JSONB queries
+CREATE INDEX IF NOT EXISTS idx_image_metadata ON image USING gin(metadata);
+
+-- Add an index to track which images have been migrated (have metadata)
+CREATE INDEX IF NOT EXISTS idx_image_metadata_not_null ON image(id) WHERE metadata IS NOT NULL;
+
+-- Note: We do NOT drop the image_meta_data_item table yet as we need to maintain backwards compatibility
+-- during the migration period
+
+-- When the drop table migration is added, we need to add an update to move any missing metadata to the new column


### PR DESCRIPTION
The image_meta_data_item table will grow large and writing to it becomes slow.  Rarely is the data used outside the context of it's associated image, so it makes sense to move it to a single aggregate field on the image record.  This change should significantly improving the overall write time for an image.

- Add JSONB metadata field
  - Add scheduled job to migrate existing images in batches
  - Add helper methods to allow both versions to exist simultaneously during migration period
  - Add feature flag to keep writing both during migration period to allow easy rollback if required