### PR TITLE
Updates to address S3 client hangs

### DIFF
--- a/image-service/build.gradle
+++ b/image-service/build.gradle
@@ -76,12 +76,13 @@ dependencies {
     implementation platform("software.amazon.awssdk:bom:$awsSdk2Version")
     implementation "software.amazon.awssdk:apache-client"
     implementation "software.amazon.awssdk:cloudwatch-metric-publisher"
-    implementation("software.amazon.awssdk:netty-nio-client")
+    implementation "software.amazon.awssdk:netty-nio-client"
+    implementation "software.amazon.awssdk:aws-crt-client"
     implementation "software.amazon.awssdk:s3"
     implementation "software.amazon.awssdk:s3-transfer-manager"
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:auth"
-    implementation("software.amazon.awssdk.crt:aws-crt:0.40.1")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.45.1")
     // TEMP: Keep AWS SDK v1 during migration; remove once all code/tests are v2
 //    implementation "com.amazonaws:aws-java-sdk-s3:1.12.418"
     implementation 'org.javaswift:joss:0.10.4'

--- a/image-service/gradle.properties
+++ b/image-service/gradle.properties
@@ -7,5 +7,5 @@ grailsGradlePluginVersion=6.2.4
 gormVersion=8.0.0
 #groovyVersion=3.0.11
 #gorm.version=7.3.2
-awsSdk2Version=2.39.5
+awsSdk2Version=2.42.37
 alaSecurityLibsVersion=7.0.1

--- a/image-service/grails-app/services/au/org/ala/images/ImageStoreService.groovy
+++ b/image-service/grails-app/services/au/org/ala/images/ImageStoreService.groovy
@@ -15,6 +15,7 @@ import au.org.ala.images.tiling.OnDemandImageTiler
 import au.org.ala.images.tiling.TileGenerationResult
 import au.org.ala.images.tiling.TilerSink
 import au.org.ala.images.util.ImageReaderUtils
+import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Cache
 import com.google.common.io.Files as GFiles
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -48,8 +49,11 @@ import java.nio.file.Files
 
 import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.function.BiFunction
 
 @Slf4j
 class ImageStoreService implements MetricsSupport {
@@ -124,15 +128,15 @@ class ImageStoreService implements MetricsSupport {
     }
 
 
-    Cache<Pair<String, String>, ImageInfo> thumbnailCache
-    Cache<Pair<String, Point>, ImageInfo> tileCache
+    AsyncCache<Pair<String, String>, ImageInfo> thumbnailCache
+    AsyncCache<Pair<String, Point>, ImageInfo> tileCache
     Cache<String, ImageInfo> originalCache
 
     @PostConstruct
     @NotTransactional
     def init() {
-        thumbnailCache = Caffeine.from(thumbnailLookupCacheConfig).build()
-        tileCache = Caffeine.from(tileLookupCacheConfig).build()
+        thumbnailCache = Caffeine.from(thumbnailLookupCacheConfig).buildAsync()
+        tileCache = Caffeine.from(tileLookupCacheConfig).buildAsync()
         originalCache = Caffeine.from(originalLookupCacheConfig).build()
     }
 
@@ -726,12 +730,14 @@ class ImageStoreService implements MetricsSupport {
         type = normaliseThumbnailType(type)
         def key = Pair.of(imageIdentifier, type)
         def loader = this.&ensureThumbnailExistsCacheLoader.curry(dataResourceUid).curry(operations)
+        BiFunction<Pair<String, String>, Executor, CompletableFuture<ImageInfo>> mappingFunction =
+                { Pair<String, String> k, Executor exec -> CompletableFuture.supplyAsync({ loader.call(k) as ImageInfo }, exec) } as BiFunction<Pair<String, String>, Executor, CompletableFuture<ImageInfo>>
 
         // TODO undefined behaviour if already loading when invalidate is called.
         if (refresh) {
-            thumbnailCache.invalidate(key)
+            thumbnailCache.synchronous().invalidate(key)
         }
-        return (disableCache ? loader.call(key) : thumbnailCache.get(key, loader)) ?: new ImageInfo(exists: false, imageIdentifier: imageIdentifier, contentType: type == 'square' ? 'image/png' : 'image/jpeg', shouldExist: true)
+        return (disableCache ? loader.call(key) : thumbnailCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: imageIdentifier, contentType: type == 'square' ? 'image/png' : 'image/jpeg', shouldExist: true)
     }
 
     private ImageInfo ensureThumbnailExistsCacheLoader(String dataResourceUid, StorageOperations operations, Pair<String, String> pair) {
@@ -819,28 +825,30 @@ class ImageStoreService implements MetricsSupport {
         }
 
         def loader = this.&ensureTileExistsCacheLoader.curry(zoomLevels).curry(operations)
+        BiFunction<Pair<String, Point>, Executor, CompletableFuture<ImageInfo>> mappingFunction =
+                { Pair<String, Point> k, Executor exec -> CompletableFuture.supplyAsync({ loader.call(k) as ImageInfo }, exec) } as BiFunction<Pair<String, Point>, Executor, CompletableFuture<ImageInfo>>
         def originKey = Pair.of(identifier, new Point(0,0,z))
         def key = Pair.of(identifier, new Point(x, y, z))
 
         // TODO undefined behaviour if already loading when invalidate is called.
         if (refresh) {
             if (onDemandTilingEnabled) {
-                tileCache.invalidate(key)
+                tileCache.synchronous().invalidate(key)
             } else {
-                tileCache.invalidateAll([originKey, key])
+                tileCache.synchronous().invalidateAll([originKey, key])
             }
         }
 
         if (onDemandTilingEnabled) {
             // experimental: With on-demand tiling, attempt to fetch/generate exactly the requested tile
-            def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, loader)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png')
+            def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png')
             tileInfo.dataResourceUid = dataResourceUid
             return tileInfo
         } else {
             // Regular behaviour:
             // First check the origin tile for the zoom level, if it doesn't exist then we can generate
             // the whole set of tiles for the level
-            def originInfo = (disableCache ? loader.call(originKey) : tileCache.get(originKey, loader)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: true, contentType: 'image/png')
+            def originInfo = (disableCache ? loader.call(originKey) : tileCache.get(originKey, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: true, contentType: 'image/png')
 
             // then if the origin was requested, return the origin info
             // or if the origin doesn't exist then any tile for the given zoom level won't exist either
@@ -850,7 +858,7 @@ class ImageStoreService implements MetricsSupport {
                 return originInfo
             } else {
                 // otherwise now we get the info for the tile that was actually requested and cache it
-                def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, loader)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png') // shouldExist is actually unknown here because we don't know the tile bounds
+                def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png') // shouldExist is actually unknown here because we don't know the tile bounds
                 tileInfo.dataResourceUid = dataResourceUid
                 return tileInfo
             }

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3StorageOperations.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3StorageOperations.groovy
@@ -18,6 +18,8 @@ import groovy.transform.TupleConstructor
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import org.slf4j.event.Level
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -27,7 +29,10 @@ import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode
 import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
 import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.http.crt.ConnectionHealthConfiguration
+import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient
 import software.amazon.awssdk.metrics.LoggingMetricPublisher
 import software.amazon.awssdk.metrics.MetricPublisher
 import software.amazon.awssdk.metrics.publishers.cloudwatch.CloudWatchMetricPublisher
@@ -104,8 +109,8 @@ class S3StorageOperations implements StorageOperations {
 
     private static final int maxConnections = Holders.getConfig().getProperty('aws.s3.max.connections', Integer, Integer.getInteger('au.org.ala.images.s3.max.connections', 500))
     private static final int maxErrorRetry = Holders.getConfig().getProperty('aws.s3.max.retry', Integer, Integer.getInteger('au.org.ala.images.s3.max.retry', 3))
-    private static final int apiCallAttemptTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.attempt', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.attempt', 60))
-    private static final int apiCallTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.call', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.call', 300))
+    private static final int apiCallAttemptTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.attempt', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.attempt', 5))
+    private static final int apiCallTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.call', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.call', 15))
     private static final int apacheConnectionTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.connection', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.connection', 2))
     private static final int socketTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.socket', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.socket', 50))
     private static final int apacheIdleTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.idle', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.idle', 5))
@@ -114,8 +119,11 @@ class S3StorageOperations implements StorageOperations {
     private static final boolean tcpKeepAlive = Holders.getConfig().getProperty('aws.s3.sync.keepalive', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.sync.keepalive', 'true')))
     private static final boolean idleReaperEnabled = Holders.getConfig().getProperty('aws.s3.sync.idlereaper', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.sync.idlereaper', 'true')))
     private static final boolean useCrtAsyncClient = Holders.getConfig().getProperty('aws.s3.crt.enabled', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.crt.enabled', 'true')))
-    private static final int crtThroughputSeconds = Holders.getConfig().getProperty('aws.s3.crt.throughput.seconds', Integer, Integer.getInteger('au.org.ala.images.s3.crt.throughput.seconds', 30))
-    private static final int crtThroughputBps = Holders.getConfig().getProperty('aws.s3.crt.throughput.bps', Integer, Integer.getInteger('au.org.ala.images.s3.crt.throughput.bps', 2))
+    private static final int crtThroughputSeconds = Holders.getConfig().getProperty('aws.s3.crt.throughput.seconds', Integer, Integer.getInteger('au.org.ala.images.s3.crt.throughput.seconds', 10))
+    // Minimum acceptable throughput for an active S3 data transfer before the CRT kills the connection.
+    // 32 KB/s is a reasonable floor for image content — well below any normal transfer rate but high enough
+    // to quickly detect a connection that has stalled after TCP establishment.
+    private static final long crtThroughputBps = Holders.getConfig().getProperty('aws.s3.crt.throughput.bps', Long, Long.getLong('au.org.ala.images.s3.crt.throughput.bps', 32 * 1024))
     private static final int crtConnectionTimeout = Holders.getConfig().getProperty('aws.s3.crt.connection.timeout', Integer, Integer.getInteger('au.org.ala.images.s3.crt.connection.timeout', 2))
     private static final boolean publishCloudwatchMetrics = Holders.getConfig().getProperty('aws.s3.cloudwatch.metrics.enabled', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.cloudwatch.metrics.enabled', 'false')))
     private static final String cloudWatchNamespace = Holders.getConfig().getProperty('aws.s3.cloudwatch.metrics.namespace', String, System.getProperty('au.org.ala.images.s3.cloudwatch.metrics.namespace', 'au.org.ala.image-service/S3'))
@@ -165,6 +173,20 @@ class S3StorageOperations implements StorageOperations {
         return s3ClientCacheLoader(key)
     }
 
+    private static final LoadingCache<CacheKey, S3AsyncClient> smallS3AsyncClientCache = Caffeine<String, S3AsyncClient>.from(asyncCacheSpec).removalListener {
+        CacheKey key, S3AsyncClient client, RemovalCause cause ->
+            log.info("S3AsyncClient evicted from cache: ${key.bucket}")
+            evictionScheduler.schedule( {
+                try {
+                    client?.close()
+                } catch (Exception e) {
+                    log.warn("Failed to close evicted S3AsyncClient", e)
+                }
+            }, inflightTimeout, TimeUnit.SECONDS)
+    }.build { CacheKey key ->
+        return s3AsyncClientCacheLoader(key, true)
+    }
+
     private static final LoadingCache<CacheKey, S3AsyncClient> s3AsyncClientCache = Caffeine<String, S3AsyncClient>.from(asyncCacheSpec).removalListener {
         CacheKey key, S3AsyncClient client, RemovalCause cause ->
             log.info("S3AsyncClient evicted from cache: ${key.bucket}")
@@ -197,6 +219,7 @@ class S3StorageOperations implements StorageOperations {
     static final void clearS3ClientCache() {
         s3TransferManagerCache.invalidateAll()
         s3AsyncClientCache.invalidateAll()
+        smallS3AsyncClientCache.invalidateAll()
         s3ClientCache.invalidateAll()
     }
 
@@ -297,12 +320,18 @@ class S3StorageOperations implements StorageOperations {
     }
 
     @VisibleForTesting
+    protected S3AsyncClient getSmallS3AsyncClient() {
+        final cacheKey = getCacheKeyObject()
+        return smallS3AsyncClientCache.get(cacheKey)
+    }
+
+    @VisibleForTesting
     protected S3AsyncClient getS3AsyncClient() {
         final cacheKey = getCacheKeyObject()
         return s3AsyncClientCache.get(cacheKey)
     }
 
-    private static S3AsyncClient s3AsyncClientCacheLoader(CacheKey key) {
+    private static S3AsyncClient s3AsyncClientCacheLoader(CacheKey key, boolean smallOps = false) {
         def containerCredentials = key.containerCredentials
         def accessKey = key.accessKey
         def secretKey = key.secretKey
@@ -317,7 +346,7 @@ class S3StorageOperations implements StorageOperations {
 
         def client
 
-        if (!useCrtAsyncClient) {
+        if (smallOps || !useCrtAsyncClient) {
             log.info("Using standard S3AsyncClient builder for S3 access")
 
             // Configure Retry Policy
@@ -334,6 +363,7 @@ class S3StorageOperations implements StorageOperations {
                     .httpClientBuilder(NettyNioAsyncHttpClient.builder()
                             .connectionTimeout(Duration.ofSeconds(apacheConnectionTimeout))
                             .connectionAcquisitionTimeout(Duration.ofSeconds(acquisitionTimeout))
+                            .connectionMaxIdleTime(Duration.ofSeconds(apacheIdleTimeout))
                             .readTimeout(Duration.ofSeconds(socketTimeout))
                             .writeTimeout(Duration.ofSeconds(socketTimeout))
                             .maxConcurrency(maxConnections)
@@ -507,6 +537,11 @@ class S3StorageOperations implements StorageOperations {
         }
     }
 
+    @VisibleForTesting
+    protected boolean isUseAsyncS3Client() {
+        return forceAsyncCalls
+    }
+
     // --- Helper methods to route via async client when forceAsyncCalls is enabled ---
 
     private S3Utilities getUtilities() {
@@ -515,8 +550,8 @@ class S3StorageOperations implements StorageOperations {
     }
 
     private void putObjectAclAsyncAware(String bkt, String key, ObjectCannedACL acl) {
-        if (forceAsyncCalls) {
-            s3AsyncClient.putObjectAcl({ PutObjectAclRequest.Builder b -> b.bucket(bkt).key(key).acl(acl) } as Consumer<PutObjectAclRequest.Builder>).join()
+        if (isUseAsyncS3Client()) {
+            smallS3AsyncClient.putObjectAcl({ PutObjectAclRequest.Builder b -> b.bucket(bkt).key(key).acl(acl) } as Consumer<PutObjectAclRequest.Builder>).join()
         } else {
             s3Client.putObjectAcl({ PutObjectAclRequest.Builder b -> b.bucket(bkt).key(key).acl(acl) } as Consumer<PutObjectAclRequest.Builder>)
         }
@@ -524,8 +559,8 @@ class S3StorageOperations implements StorageOperations {
 
     private HeadObjectResponse headObjectAsyncAware(String bkt, String key) {
         return recordMetric(s3HeadObjectTimer) {
-            if (forceAsyncCalls) {
-                return s3AsyncClient.headObject({ HeadObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<HeadObjectRequest.Builder>).join()
+            if (isUseAsyncS3Client()) {
+                return smallS3AsyncClient.headObject({ HeadObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<HeadObjectRequest.Builder>).join()
             }
             return s3Client.headObject({ HeadObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<HeadObjectRequest.Builder>)
         }
@@ -533,8 +568,8 @@ class S3StorageOperations implements StorageOperations {
 
     private void copyObjectAsyncAware(Consumer<V2CopyObjectRequest.Builder> consumer) {
         recordMetric(s3CopyObjectTimer) {
-            if (forceAsyncCalls) {
-                s3AsyncClient.copyObject(consumer).join()
+            if (isUseAsyncS3Client()) {
+                smallS3AsyncClient.copyObject(consumer).join()
             } else {
                 s3Client.copyObject(consumer)
             }
@@ -543,8 +578,8 @@ class S3StorageOperations implements StorageOperations {
     }
 
     private void headBucketAsyncAware(String bkt) {
-        if (forceAsyncCalls) {
-            s3AsyncClient.headBucket({ HeadBucketRequest.Builder b -> b.bucket(bkt) } as Consumer<HeadBucketRequest.Builder>).join()
+        if (isUseAsyncS3Client()) {
+            smallS3AsyncClient.headBucket({ HeadBucketRequest.Builder b -> b.bucket(bkt) } as Consumer<HeadBucketRequest.Builder>).join()
         } else {
             s3Client.headBucket({ HeadBucketRequest.Builder b -> b.bucket(bkt) } as Consumer<HeadBucketRequest.Builder>)
         }
@@ -552,8 +587,8 @@ class S3StorageOperations implements StorageOperations {
 
     private void deleteObjectAsyncAware(String bkt, String key) {
         recordMetric(s3DeleteObjectTimer) {
-            if (forceAsyncCalls) {
-                s3AsyncClient.deleteObject({ DeleteObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<DeleteObjectRequest.Builder>).join()
+            if (isUseAsyncS3Client()) {
+                smallS3AsyncClient.deleteObject({ DeleteObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<DeleteObjectRequest.Builder>).join()
             } else {
                 s3Client.deleteObject({ DeleteObjectRequest.Builder b -> b.bucket(bkt).key(key) } as Consumer<DeleteObjectRequest.Builder>)
             }
@@ -564,8 +599,8 @@ class S3StorageOperations implements StorageOperations {
     private void putObjectSmallAsyncAware(String bkt, String key, String contentType, byte[] bytes) {
         recordMetric(s3PutObjectTimer) {
             def consumer = { PutObjectRequest.Builder b -> b.bucket(bkt).key(key).contentType(contentType) } as Consumer<PutObjectRequest.Builder>
-            if (forceAsyncCalls) {
-                s3AsyncClient.putObject(consumer, AsyncRequestBody.fromBytes(bytes)).join()
+            if (isUseAsyncS3Client()) {
+                smallS3AsyncClient.putObject(consumer, AsyncRequestBody.fromBytes(bytes)).join()
             } else {
                 s3Client.putObject(consumer, RequestBody.fromBytes(bytes))
             }
@@ -576,7 +611,7 @@ class S3StorageOperations implements StorageOperations {
     private void putObjectStreamAsyncAware(String bkt, String key, String contentType, InputStream stream, long length) {
         recordMetric(s3PutObjectTimer) {
             def consumer = { PutObjectRequest.Builder b -> b.bucket(bkt).key(key).contentType(contentType) } as Consumer<PutObjectRequest.Builder>
-            if (forceAsyncCalls) {
+            if (isUseAsyncS3Client()) {
                 // Use TransferManager with a blocking async request body to stream data
                 def transferManager = getS3TransferManager()
                 def blockingBody = BlockingOutputStreamAsyncRequestBody.builder().build()
@@ -604,7 +639,7 @@ class S3StorageOperations implements StorageOperations {
                     b.range("bytes=${range.start()}-${range.end()}")
                 }
             } as Consumer<V2GetObjectRequest.Builder>
-            if (forceAsyncCalls) {
+            if (isUseAsyncS3Client()) {
                 def resp = s3AsyncClient.getObject(consumer, AsyncResponseTransformer.toBytes()).join()
                 return resp.asByteArray()
             } else {
@@ -621,7 +656,7 @@ class S3StorageOperations implements StorageOperations {
 
     private ListResult listObjectsV2AsyncAware(String bkt, String prefix, String delimiter) {
         return recordMetric(s3ListObjectsTimer) {
-            if (!forceAsyncCalls) {
+            if (!isUseAsyncS3Client()) {
                 ListObjectsV2Iterable pages = s3Client.listObjectsV2Paginator({ ListObjectsV2Request.Builder b -> b.bucket(bkt).prefix(prefix).delimiter(delimiter) } as Consumer<ListObjectsV2Request.Builder>)
                 ListResult lr = new ListResult()
                 pages.each { page ->
@@ -632,10 +667,10 @@ class S3StorageOperations implements StorageOperations {
             }
             ListResult result = new ListResult()
             CountDownLatch latch = new CountDownLatch(1)
-            def publisher = s3AsyncClient.listObjectsV2Paginator({ ListObjectsV2Request.Builder b -> b.bucket(bkt).prefix(prefix).delimiter(delimiter) } as Consumer<ListObjectsV2Request.Builder>)
-            publisher.subscribe(new org.reactivestreams.Subscriber<ListObjectsV2Response>() {
-                org.reactivestreams.Subscription s
-                @Override void onSubscribe(org.reactivestreams.Subscription s) { this.s = s; s.request(Long.MAX_VALUE) }
+            def publisher = smallS3AsyncClient.listObjectsV2Paginator({ ListObjectsV2Request.Builder b -> b.bucket(bkt).prefix(prefix).delimiter(delimiter) } as Consumer<ListObjectsV2Request.Builder>)
+            publisher.subscribe(new Subscriber<ListObjectsV2Response>() {
+                Subscription s
+                @Override void onSubscribe(Subscription s) { this.s = s; s.request(Long.MAX_VALUE) }
                 @Override void onNext(ListObjectsV2Response page) {
                     result.contents.addAll(page.contents())
                     result.commonPrefixes.addAll(page.commonPrefixes().collect { it.prefix() })
@@ -799,7 +834,7 @@ class S3StorageOperations implements StorageOperations {
             } as Consumer<V2GetObjectRequest.Builder>
 
             InputStream rawStream
-            if (forceAsyncCalls) {
+            if (isUseAsyncS3Client()) {
                 rawStream = s3AsyncClient
                         .getObject(consumer, AsyncResponseTransformer.toBlockingInputStream())
                         .join()
@@ -1042,7 +1077,7 @@ class S3StorageOperations implements StorageOperations {
             final String k = obj['key'] as String
             def head = headObjectAsyncAware(bkt, k)
             InputStream objectStream
-            if (forceAsyncCalls) {
+            if (isUseAsyncS3Client()) {
                 def consumer = { V2GetObjectRequest.Builder b -> b.bucket(bkt).key(k) } as Consumer<V2GetObjectRequest.Builder>
                 objectStream = s3AsyncClient.getObject(consumer, AsyncResponseTransformer.toBlockingInputStream()).join()
             } else {

--- a/image-service/src/test/groovy/au/org/ala/images/ImageStoreServiceSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/ImageStoreServiceSpec.groovy
@@ -1,5 +1,6 @@
 package au.org.ala.images
 
+import au.org.ala.images.storage.StorageOperations
 import au.org.ala.images.thumb.IImageThumbnailer
 import au.org.ala.images.tiling.IImageTiler
 import au.org.ala.images.tiling.IOnDemandImageTiler
@@ -8,6 +9,12 @@ import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.grails.plugins.testing.GrailsMockMultipartFile
 import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<ImageStoreService>, DataTest {
 
@@ -45,6 +52,72 @@ class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<Ima
         // file entries do call storeTileZipInputStream
         1 * storageLocation.storeTileZipInputStream(uuid, '0/0/0.png', 'image/jpeg', 1994, _)
         1 *  service.auditService.log(uuid, 'Image tiles stored from zip file (outsourced job?)', 'N/A')
+    }
+
+    def "thumbnailImageInfo coalesces concurrent loads for same key when cache is enabled"() {
+        given:
+        service.initSemaphores()
+        service.init()
+        service.disableCache = false
+        def callCount = new AtomicInteger(0)
+        def operations = Stub(StorageOperations) {
+            thumbnailImageInfo('img-1', '') >> {
+                callCount.incrementAndGet()
+                Thread.sleep(200)
+                new ImageInfo(exists: true, imageIdentifier: 'img-1', contentType: 'image/jpeg', extension: 'jpg', inputStreamSupplier: { r -> new ByteArrayInputStream(new byte[0]) })
+            }
+        }
+        service.storageLocationService.getStorageOperationsWithoutDbLookup() >> operations
+
+        def gate = new CountDownLatch(1)
+        def pool = Executors.newFixedThreadPool(2)
+
+        when:
+        def f1 = pool.submit({ gate.await(); service.thumbnailImageInfo('img-1', '', false) } as Callable<ImageInfo>)
+        def f2 = pool.submit({ gate.await(); service.thumbnailImageInfo('img-1', '', false) } as Callable<ImageInfo>)
+        gate.countDown()
+        def r1 = f1.get(5, TimeUnit.SECONDS)
+        def r2 = f2.get(5, TimeUnit.SECONDS)
+
+        then:
+        r1.exists
+        r2.exists
+        callCount.get() == 1
+
+        cleanup:
+        pool.shutdownNow()
+    }
+
+    def "thumbnailImageInfo performs separate loads when cache is disabled"() {
+        given:
+        service.initSemaphores()
+        service.init()
+        service.disableCache = true
+        def callCount = new AtomicInteger(0)
+        def operations = Stub(StorageOperations) {
+            thumbnailImageInfo('img-2', '') >> {
+                callCount.incrementAndGet()
+                Thread.sleep(100)
+                new ImageInfo(exists: true, imageIdentifier: 'img-2', contentType: 'image/jpeg', extension: 'jpg', inputStreamSupplier: { r -> new ByteArrayInputStream(new byte[0]) })
+            }
+        }
+        service.storageLocationService.getStorageOperationsWithoutDbLookup() >> operations
+
+        def gate = new CountDownLatch(1)
+        def pool = Executors.newFixedThreadPool(2)
+
+        when:
+        def f1 = pool.submit({ gate.await(); service.thumbnailImageInfo('img-2', '', false) } as Callable<ImageInfo>)
+        def f2 = pool.submit({ gate.await(); service.thumbnailImageInfo('img-2', '', false) } as Callable<ImageInfo>)
+        gate.countDown()
+        f1.get(5, TimeUnit.SECONDS)
+        f2.get(5, TimeUnit.SECONDS)
+
+        then:
+        callCount.get() == 2
+
+        cleanup:
+        pool.shutdownNow()
     }
 
 }

--- a/image-service/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
@@ -2,14 +2,19 @@ package au.org.ala.images
 
 import au.org.ala.images.storage.S3StorageOperations
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.core.ResponseBytes
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectAclRequest
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import software.amazon.awssdk.services.s3.model.S3Object
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable
@@ -32,13 +37,25 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
 
     private static class TestOps extends S3StorageOperations {
         S3Client mockClient
+        S3AsyncClient mockSmallAsyncClient
+        S3AsyncClient mockAsyncClient
         S3TransferManager mockTransferManager
+        boolean forceAsync = false
 
         @Override
         protected S3Client getS3Client() { return mockClient }
 
         @Override
+        protected S3AsyncClient getSmallS3AsyncClient() { return mockSmallAsyncClient }
+
+        @Override
+        protected S3AsyncClient getS3AsyncClient() { return mockAsyncClient }
+
+        @Override
         protected S3TransferManager getS3TransferManager() { return mockTransferManager }
+
+        @Override
+        protected boolean isUseAsyncS3Client() { return forceAsync }
     }
 
     private void consumeBody(UploadRequest req) {
@@ -192,5 +209,60 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
         0 * client.putObjectAcl(_)
         1 * client.headObject(_ as Consumer<HeadObjectRequest.Builder>) >> { Consumer<HeadObjectRequest.Builder> c -> }
         1 * client.copyObject(_ as Consumer<CopyObjectRequest.Builder>)
+    }
+
+    def "verifySettings uses small async client for head/put/delete when forceAsync is enabled"() {
+        given:
+        def smallAsync = Mock(S3AsyncClient)
+        def regularAsync = Mock(S3AsyncClient)
+        def client = Mock(S3Client)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+
+        when:
+        def result = ops.verifySettings()
+
+        then:
+        result
+        1 * smallAsync.headBucket(_ as Consumer) >> CompletableFuture.completedFuture(HeadBucketResponse.builder().build())
+        1 * smallAsync.putObject(_ as Consumer, _) >> CompletableFuture.completedFuture(PutObjectResponse.builder().eTag('etag').build())
+        1 * smallAsync.deleteObject(_ as Consumer) >> CompletableFuture.completedFuture(DeleteObjectResponse.builder().build())
+        0 * client._
+        0 * regularAsync._
+    }
+
+    def "stored uses small async client headObject when forceAsync is enabled"() {
+        given:
+        def smallAsync = Mock(S3AsyncClient)
+        def regularAsync = Mock(S3AsyncClient)
+        def client = Mock(S3Client)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+
+        when:
+        def exists = ops.stored('uuid-1')
+
+        then:
+        exists
+        1 * smallAsync.headObject(_ as Consumer) >> CompletableFuture.completedFuture(HeadObjectResponse.builder().build())
+        0 * client._
+        0 * regularAsync._
+    }
+
+    def "retrieve still uses main async client when forceAsync is enabled"() {
+        given:
+        def smallAsync = Mock(S3AsyncClient)
+        def regularAsync = Mock(S3AsyncClient)
+        def client = Mock(S3Client)
+        def bytes = 'abc'.bytes
+        def responseBytes = ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), bytes)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+
+        when:
+        def actual = ops.retrieve('uuid-2')
+
+        then:
+        actual == bytes
+        1 * regularAsync.getObject(_ as Consumer, _) >> CompletableFuture.completedFuture(responseBytes)
+        0 * smallAsync.getObject(_, _)
+        0 * client._
     }
 }


### PR DESCRIPTION
- Working theory is this is NAT timeouts not being detected by pooled connections
- Update small S3 ops (ie head, etc) to use a separate netty based async client from uploads/downloads
- Update some S3 timeout values to be less generous
- Update S3 CRT throughput monitor values to be less generous but wait longer
- Add tests for new S3 Storage Operation behaviour
- Update ImageStoreService to use AsyncCaches instead of blocking
  - No change in behaviour but less Caffeine lock contention