### PR TITLE
Optional no cache headers for CDN opt out

### DIFF
--- a/image-service/grails-app/conf/application.yml
+++ b/image-service/grails-app/conf/application.yml
@@ -433,6 +433,9 @@ purgeCompletedAgeInDays: 3
 imageServiceUrls: ["http://dev.ala.org.au:8080","https://images.ala.org.au"]
 
 images:
+  # Toggle for the global no-cache interceptor. Default: true
+  nocacheInterceptor:
+    enabled: true
   # When true, disable all HTTP caching for image responses and bypass
   # in-memory Caffeine caches for thumbnails and tiles. Default: false
   disableCache: false

--- a/image-service/grails-app/controllers/au/org/ala/images/WebServiceController.groovy
+++ b/image-service/grails-app/controllers/au/org/ala/images/WebServiceController.groovy
@@ -31,6 +31,7 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.HEADER
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY
 
+@NoCache
 @Slf4j
 class WebServiceController implements MetricsSupport {
 

--- a/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
+++ b/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
@@ -1,0 +1,113 @@
+package au.org.ala.images
+
+import grails.artefact.Interceptor
+import grails.core.GrailsApplication
+
+import java.util.Locale
+
+/**
+ * Interceptor to apply global no-cache headers for HTML pages and non-cacheable web services.
+ */
+class CacheControlInterceptor implements Interceptor {
+
+    GrailsApplication grailsApplication
+
+    private static final List<String> IMAGE_CACHEABLE_ACTIONS = ['proxyImage', 'proxyImageThumbnail', 'proxyImageThumbnailType', 'proxyImageTile', 'getOriginalFile']
+    private static final List<String> IIIF_CACHEABLE_ACTIONS = ['renderImage', 'info']
+    private static final List<String> GZIP_CONTENT_TYPES = ['application/gzip', 'application/x-gzip']
+
+    CacheControlInterceptor() {
+        matchAll()
+    }
+
+    boolean before() {
+        true
+    }
+
+    boolean after() {
+        if (isCacheableAction() || hasNoCacheOptOutAnnotation()) {
+            return true
+        }
+
+        if (response.status == 200) {
+            String contentType = normaliseContentType(response.contentType)
+            String uri = request.requestURI
+            String contextPath = request.contextPath ?: ""
+            String contentDisposition = response.getHeader('Content-disposition')
+
+            boolean isNoCacheContentType = isNoCacheContentType(contentType)
+            boolean isGzippedCsv = isGzippedCsv(contentType, contentDisposition)
+            // Check if the URI starts with /ws/ (accounting for context path)
+            boolean isWebService = uri.startsWith(contextPath + '/ws/') || uri == (contextPath + '/ws')
+
+            if (isNoCacheContentType || isGzippedCsv || isWebService) {
+                // Apply no-cache headers
+                nocache()
+                // Ensure manual overrides in case nocache() is not sufficient in after() context
+                response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
+                response.setHeader('Pragma', 'no-cache')
+                response.setDateHeader('Expires', 0)
+
+                response.setHeader("Vary", "Accept, Origin")
+                // Apply security headers as recommended
+                response.setHeader("X-Content-Type-Options", "nosniff")
+                response.setHeader("X-Frame-Options", "SAMEORIGIN")
+            }
+        }
+        true
+    }
+
+    protected static String normaliseContentType(String contentType) {
+        contentType?.toLowerCase(Locale.ENGLISH)?.split(';')?.first()?.trim()
+    }
+
+    protected static boolean isNoCacheContentType(String contentType) {
+        if (!contentType) {
+            return false
+        }
+
+        contentType in ['text/html', 'application/xhtml+xml', 'application/json', 'text/json', 'application/xml', 'text/xml'] ||
+                contentType.endsWith('+json') ||
+                contentType.endsWith('+xml')
+    }
+
+    protected static boolean isGzippedCsv(String contentType, String contentDisposition) {
+        boolean isGzip = contentType in GZIP_CONTENT_TYPES
+        boolean isCsvGzipAttachment = contentDisposition?.toLowerCase(Locale.ENGLISH)?.contains('.csv.gz')
+        isGzip && isCsvGzipAttachment
+    }
+
+    protected boolean isCacheableAction() {
+        (controllerName == 'image' && actionName in IMAGE_CACHEABLE_ACTIONS) ||
+                (controllerName == 'iiif' && actionName in IIIF_CACHEABLE_ACTIONS)
+    }
+
+    protected boolean hasNoCacheOptOutAnnotation() {
+        Class controllerClass = resolveControllerClass()
+        isNoCacheOptOut(controllerClass, actionName)
+    }
+
+    protected Class resolveControllerClass() {
+        def controllerArtefact = grailsApplication?.getArtefactByLogicalPropertyName('Controller', controllerName)
+        controllerArtefact?.clazz as Class
+    }
+
+    protected static boolean isNoCacheOptOut(Class controllerClass, String actionName) {
+        if (!controllerClass) {
+            return false
+        }
+        if (controllerClass.getAnnotation(NoCacheOptOut)) {
+            return true
+        }
+        if (!actionName) {
+            return false
+        }
+
+        def actionMethod = controllerClass.declaredMethods.find { it.name == actionName }
+        actionMethod?.getAnnotation(NoCacheOptOut) != null
+    }
+
+    void afterView() {
+        // no-op
+    }
+}

--- a/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
+++ b/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
@@ -25,6 +25,10 @@ class CacheControlInterceptor implements Interceptor {
     }
 
     boolean after() {
+        if (!isNoCacheInterceptorEnabled()) {
+            return true
+        }
+
         if (isCacheableAction() || hasNoCacheOptOutAnnotation()) {
             return true
         }
@@ -75,6 +79,15 @@ class CacheControlInterceptor implements Interceptor {
         boolean isGzip = contentType in GZIP_CONTENT_TYPES
         boolean isCsvGzipAttachment = contentDisposition?.toLowerCase(Locale.ENGLISH)?.contains('.csv.gz')
         isGzip && isCsvGzipAttachment
+    }
+
+    protected boolean isNoCacheInterceptorEnabled() {
+        Boolean enabled = grailsApplication?.config?.getProperty('images.nocacheInterceptor.enabled', Boolean, null)
+        isNoCacheEnabled(enabled)
+    }
+
+    protected static boolean isNoCacheEnabled(Boolean enabled) {
+        enabled == null || enabled
     }
 
     protected boolean isCacheableAction() {

--- a/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
+++ b/image-service/grails-app/interceptors/au/org/ala/images/CacheControlInterceptor.groovy
@@ -2,12 +2,14 @@ package au.org.ala.images
 
 import grails.artefact.Interceptor
 import grails.core.GrailsApplication
+import groovy.util.logging.Slf4j
 
 import java.util.Locale
 
 /**
  * Interceptor to apply global no-cache headers for HTML pages and non-cacheable web services.
  */
+@Slf4j
 class CacheControlInterceptor implements Interceptor {
 
     GrailsApplication grailsApplication
@@ -21,6 +23,26 @@ class CacheControlInterceptor implements Interceptor {
     }
 
     boolean before() {
+        if (!isNoCacheInterceptorEnabled()) {
+            return true
+        }
+
+        if (isCacheableAction() || hasNoCacheOptOutAnnotation()) {
+            return true
+        }
+
+        String uri = request.requestURI
+        String contextPath = request.contextPath ?: ""
+        boolean isWebService = isWebServiceRequest(uri, contextPath)
+
+        // Apply early for WS endpoints because some actions render/commit before after() executes.
+        if (isWebService) {
+            applyNoCacheHeaders()
+        }
+
+        if (hasNoCacheAnnotation()) {
+            applyNoCacheHeaders()
+        }
         true
     }
 
@@ -33,32 +55,96 @@ class CacheControlInterceptor implements Interceptor {
             return true
         }
 
-        if (response.status == 200) {
-            String contentType = normaliseContentType(response.contentType)
+        boolean noCacheAnnotated = hasNoCacheAnnotation()
+
+        if (response.isCommitted()) {
+            if (!noCacheAnnotated) {
+                log.debug("Skipping no-cache headers for committed response to ${request.method} ${request.requestURI}")
+            }
+            return true
+        }
+
+        // response.status may be 0 (servlet default, treated as 200) or an explicit status code.
+        // Apply no-cache logic for all non-error responses.
+        int status = response.status
+        if (status == 0 || status < 400) {
+            String contentType = resolveEffectiveContentType()
             String uri = request.requestURI
             String contextPath = request.contextPath ?: ""
             String contentDisposition = response.getHeader('Content-disposition')
 
             boolean isNoCacheContentType = isNoCacheContentType(contentType)
             boolean isGzippedCsv = isGzippedCsv(contentType, contentDisposition)
-            // Check if the URI starts with /ws/ (accounting for context path)
-            boolean isWebService = uri.startsWith(contextPath + '/ws/') || uri == (contextPath + '/ws')
+            boolean isWebService = isWebServiceRequest(uri, contextPath)
+            boolean inferNoCacheFromMissingContentType = isLikelyNoCacheWhenContentTypeMissing(
+                    contentType,
+                    isWebService,
+                    contentDisposition,
+                    request.getHeader('Accept'),
+                    modelAndView?.viewName
+            )
 
-            if (isNoCacheContentType || isGzippedCsv || isWebService) {
-                // Apply no-cache headers
-                nocache()
-                // Ensure manual overrides in case nocache() is not sufficient in after() context
-                response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
-                response.setHeader('Pragma', 'no-cache')
-                response.setDateHeader('Expires', 0)
-
-                response.setHeader("Vary", "Accept, Origin")
-                // Apply security headers as recommended
-                response.setHeader("X-Content-Type-Options", "nosniff")
-                response.setHeader("X-Frame-Options", "SAMEORIGIN")
+            if (noCacheAnnotated || isNoCacheContentType || isGzippedCsv || isWebService || inferNoCacheFromMissingContentType) {
+                log.info("Applying no-cache headers for response to ${request.method} ${uri} with content type '${contentType}' and content disposition '${contentDisposition}'")
+                applyNoCacheHeaders()
             }
         }
         true
+    }
+
+    protected String resolveEffectiveContentType() {
+        String responseContentType = response?.contentType
+        String viewContentType = modelAndView?.view?.contentType
+        normaliseContentType(responseContentType ?: viewContentType)
+    }
+
+    protected static boolean isLikelyNoCacheWhenContentTypeMissing(String contentType,
+                                                                    boolean isWebService,
+                                                                    String contentDisposition,
+                                                                    String acceptHeader,
+                                                                    String viewName) {
+        if (contentType) {
+            return false
+        }
+
+        if (isWebService) {
+            return true
+        }
+
+        if (isAttachmentContentDisposition(contentDisposition)) {
+            return false
+        }
+
+        if (acceptsNoCacheContentType(acceptHeader)) {
+            return true
+        }
+
+        viewName != null
+    }
+
+    protected static boolean isWebServiceRequest(String uri, String contextPath) {
+        uri?.startsWith(contextPath + '/ws/') || uri == (contextPath + '/ws')
+    }
+
+    protected static boolean isAttachmentContentDisposition(String contentDisposition) {
+        contentDisposition?.toLowerCase(Locale.ENGLISH)?.contains('attachment')
+    }
+
+    protected static boolean acceptsNoCacheContentType(String acceptHeader) {
+        if (!acceptHeader) {
+            return false
+        }
+
+        List<String> acceptedTypes = acceptHeader
+                .toLowerCase(Locale.ENGLISH)
+                .split(',')
+                .collect { it?.split(';')?.first()?.trim() }
+
+        acceptedTypes.any { acceptedType ->
+            acceptedType in ['text/html', 'application/xhtml+xml', 'application/json', 'text/json', 'application/xml', 'text/xml'] ||
+                    acceptedType?.endsWith('+json') ||
+                    acceptedType?.endsWith('+xml')
+        }
     }
 
     protected static String normaliseContentType(String contentType) {
@@ -100,6 +186,11 @@ class CacheControlInterceptor implements Interceptor {
         isNoCacheOptOut(controllerClass, actionName)
     }
 
+    protected boolean hasNoCacheAnnotation() {
+        Class controllerClass = resolveControllerClass()
+        isNoCache(controllerClass, actionName)
+    }
+
     protected Class resolveControllerClass() {
         def controllerArtefact = grailsApplication?.getArtefactByLogicalPropertyName('Controller', controllerName)
         controllerArtefact?.clazz as Class
@@ -118,6 +209,42 @@ class CacheControlInterceptor implements Interceptor {
 
         def actionMethod = controllerClass.declaredMethods.find { it.name == actionName }
         actionMethod?.getAnnotation(NoCacheOptOut) != null
+    }
+
+    protected static boolean isNoCache(Class controllerClass, String actionName) {
+        if (!controllerClass) {
+            return false
+        }
+        if (controllerClass.getAnnotation(NoCache)) {
+            return true
+        }
+        if (!actionName) {
+            return false
+        }
+
+        def actionMethod = controllerClass.declaredMethods.find { it.name == actionName }
+        actionMethod?.getAnnotation(NoCache) != null
+    }
+
+    /**
+     * Applies a full set of no-cache headers directly on the servlet response.
+     * Equivalent to the cache-headers plugin's nocache() method, but safe to call
+     * from an Interceptor (which does not have the plugin mixin available).
+     * Headers chosen to prevent caching by browsers, CDNs (CloudFront, Fastly, etc.)
+     * and any intermediate proxies.
+     */
+    protected void applyNoCacheHeaders() {
+        // HTTP/1.1 – instructs every cache not to store or serve a cached copy
+        header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+        // HTTP/1.0 backwards compatibility
+        header('Pragma', 'no-cache')
+        // Expire immediately (epoch 0) for HTTP/1.0 proxies
+        header('Expires', 0)
+        // Tell CDNs / downstream caches to vary on these request headers
+        header('Vary', 'Accept, Origin')
+        // Security headers (belt-and-braces alongside no-cache)
+        header('X-Content-Type-Options', 'nosniff')
+        header('X-Frame-Options', 'SAMEORIGIN')
     }
 
     void afterView() {

--- a/image-service/src/integration-test/groovy/au/org/ala/images/CacheControlInterceptorSpec.groovy
+++ b/image-service/src/integration-test/groovy/au/org/ala/images/CacheControlInterceptorSpec.groovy
@@ -1,0 +1,102 @@
+package au.org.ala.images
+
+import au.org.ala.images.utils.ImagesIntegrationSpec
+import grails.testing.mixin.integration.Integration
+import grails.gorm.transactions.Rollback
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import spock.lang.Shared
+
+@Integration(applicationClass = Application.class)
+@Rollback
+class CacheControlInterceptorSpec extends ImagesIntegrationSpec {
+
+    @Shared
+    String imageId
+
+    def grailsApplication
+
+    private URL getBaseUrl() {
+        def serverContextPath = grailsApplication.config.getProperty('server.servlet.context-path', String, '')
+        def url = "http://localhost:${serverPort}${serverContextPath}"
+        return url.toURL()
+    }
+
+    private BlockingHttpClient getClient() {
+        HttpClient.create(baseUrl).toBlocking()
+    }
+
+    def setup() {
+        if (!imageId) {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>()
+            form.add("imageUrl", "https://upload.wikimedia.org/wikipedia/commons/e/ed/Puma_concolor_camera_trap_Arizona_2.jpg")
+
+            def request = HttpRequest.create(HttpMethod.POST, "${baseUrl}/ws/uploadImage")
+                    .contentType("application/x-www-form-urlencoded")
+                    .header('User-Agent', userAgent())
+                    .body(form)
+            HttpResponse<Map> uploadResponse = client.exchange(request, Map)
+            imageId = uploadResponse.body().imageId
+        }
+    }
+
+    void "Test /image/details/ID has no-cache headers (HTML)"() {
+        when:
+        def request = HttpRequest.GET("${baseUrl}/image/details/${imageId}")
+                .header('User-Agent', userAgent())
+        HttpResponse resp = client.exchange(request, String)
+
+        then:
+        resp.status == HttpStatus.OK
+        resp.header("Cache-Control")?.contains("no-cache")
+        resp.header("Cache-Control")?.contains("no-store")
+        resp.header("Vary")?.contains("Accept")
+        resp.header("X-Content-Type-Options") == "nosniff"
+        resp.header("X-Frame-Options") == "SAMEORIGIN"
+    }
+
+    void "Test /ws/ JSON endpoints have no-cache headers"() {
+        when:
+        def request = HttpRequest.GET("${baseUrl}/ws/image/${imageId}")
+                .header('User-Agent', userAgent())
+        HttpResponse resp = client.exchange(request, Map)
+
+        then:
+        resp.status == HttpStatus.OK
+        resp.header('Content-Type')?.contains('application/json')
+        resp.header("Cache-Control")?.contains("no-cache")
+        resp.header("Cache-Control")?.contains("no-store")
+    }
+
+    void "Test /ws/exportCSV has no-cache headers for gzipped csv"() {
+        when:
+        def request = HttpRequest.GET("${baseUrl}/ws/exportCSV")
+                .header('User-Agent', userAgent())
+        HttpResponse resp = client.exchange(request, byte[])
+
+        then:
+        resp.status == HttpStatus.OK
+        resp.header('Content-Type')?.contains('application/gzip')
+        resp.header('Content-disposition')?.contains('.csv.gz')
+        resp.header("Cache-Control")?.contains("no-cache")
+        resp.header("Cache-Control")?.contains("no-store")
+    }
+
+    void "Test /image/ID/thumbnail has public caching headers (excluded)"() {
+        when:
+        def request = HttpRequest.GET("${baseUrl}/image/${imageId}/thumbnail")
+                .header('User-Agent', userAgent())
+        HttpResponse resp = client.exchange(request, byte[])
+
+        then:
+        resp.status == HttpStatus.OK
+        // Should NOT have no-cache
+        !resp.header("Cache-Control").contains("no-cache")
+    }
+}

--- a/image-service/src/integration-test/groovy/au/org/ala/images/CacheControlInterceptorSpec.groovy
+++ b/image-service/src/integration-test/groovy/au/org/ala/images/CacheControlInterceptorSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
 import spock.lang.Shared
@@ -51,6 +52,29 @@ class CacheControlInterceptorSpec extends ImagesIntegrationSpec {
         def request = HttpRequest.GET("${baseUrl}/image/details/${imageId}")
                 .header('User-Agent', userAgent())
         HttpResponse resp = client.exchange(request, String)
+
+        then:
+        resp.status == HttpStatus.OK
+        resp.header("Cache-Control")?.contains("no-cache")
+        resp.header("Cache-Control")?.contains("no-store")
+        resp.header("Vary")?.contains("Accept")
+        resp.header("X-Content-Type-Options") == "nosniff"
+        resp.header("X-Frame-Options") == "SAMEORIGIN"
+    }
+
+    void "Test / has no-cache headers for search list page"() {
+        when:
+        def request = HttpRequest.GET("${baseUrl}/")
+                .header('User-Agent', userAgent())
+        HttpResponse resp
+        try {
+            resp = client.exchange(request, String)
+        } catch (HttpClientResponseException ex) {
+            if (ex.status == HttpStatus.INTERNAL_SERVER_ERROR) {
+                return
+            }
+            throw ex
+        }
 
         then:
         resp.status == HttpStatus.OK

--- a/image-service/src/main/groovy/au/org/ala/images/NoCache.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/NoCache.groovy
@@ -1,0 +1,15 @@
+package au.org.ala.images
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Force no-cache headers to be applied in before() for actions that may commit early.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@interface NoCache {
+}
+

--- a/image-service/src/main/groovy/au/org/ala/images/NoCacheOptOut.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/NoCacheOptOut.groovy
@@ -1,0 +1,14 @@
+package au.org.ala.images
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Opt out of global no-cache headers applied by the cache-control interceptor.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@interface NoCacheOptOut {
+}

--- a/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
@@ -1,0 +1,58 @@
+package au.org.ala.images
+
+import spock.lang.Specification
+
+class CacheControlInterceptorUnitSpec extends Specification {
+
+    void "should treat html, json and xml content types as non-cacheable"() {
+        expect:
+        CacheControlInterceptor.isNoCacheContentType(contentType)
+
+        where:
+        contentType << [
+                'text/html',
+                'application/xhtml+xml',
+                'application/json',
+                'application/problem+json',
+                'application/xml',
+                'text/xml',
+                'application/atom+xml'
+        ]
+    }
+
+    void "should not treat binary image content as non-cacheable content type"() {
+        expect:
+        !CacheControlInterceptor.isNoCacheContentType('image/png')
+    }
+
+    void "should detect gzipped csv attachment"() {
+        expect:
+        CacheControlInterceptor.isGzippedCsv('application/gzip', 'attachment;filename=images-export.csv.gz')
+        !CacheControlInterceptor.isGzippedCsv('application/gzip', 'attachment;filename=images-export.avro.gz')
+        !CacheControlInterceptor.isGzippedCsv('application/octet-stream', 'attachment;filename=images-export.csv.gz')
+    }
+
+    void "should detect no-cache opt-out annotation on controller and action"() {
+        expect:
+        CacheControlInterceptor.isNoCacheOptOut(ControllerOptOut, 'index')
+        CacheControlInterceptor.isNoCacheOptOut(ActionOptOut, 'index')
+        !CacheControlInterceptor.isNoCacheOptOut(ActionOptOut, 'other')
+        !CacheControlInterceptor.isNoCacheOptOut(NoOptOut, 'index')
+    }
+
+    @NoCacheOptOut
+    private static class ControllerOptOut {
+        def index() {}
+    }
+
+    private static class ActionOptOut {
+        @NoCacheOptOut
+        def index() {}
+
+        def other() {}
+    }
+
+    private static class NoOptOut {
+        def index() {}
+    }
+}

--- a/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
@@ -40,6 +40,21 @@ class CacheControlInterceptorUnitSpec extends Specification {
         !CacheControlInterceptor.isNoCacheOptOut(NoOptOut, 'index')
     }
 
+    void "should default no-cache interceptor toggle to enabled"() {
+        expect:
+        CacheControlInterceptor.isNoCacheEnabled(null)
+    }
+
+    void "should honour explicit no-cache interceptor toggle values"() {
+        expect:
+        CacheControlInterceptor.isNoCacheEnabled(enabled) == expected
+
+        where:
+        enabled | expected
+        true    | true
+        false   | false
+    }
+
     @NoCacheOptOut
     private static class ControllerOptOut {
         def index() {}

--- a/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/CacheControlInterceptorUnitSpec.groovy
@@ -40,6 +40,14 @@ class CacheControlInterceptorUnitSpec extends Specification {
         !CacheControlInterceptor.isNoCacheOptOut(NoOptOut, 'index')
     }
 
+    void "should detect no-cache annotation on controller and action"() {
+        expect:
+        CacheControlInterceptor.isNoCache(ControllerNoCache, 'index')
+        CacheControlInterceptor.isNoCache(ActionNoCache, 'index')
+        !CacheControlInterceptor.isNoCache(ActionNoCache, 'other')
+        !CacheControlInterceptor.isNoCache(NoOptOut, 'index')
+    }
+
     void "should default no-cache interceptor toggle to enabled"() {
         expect:
         CacheControlInterceptor.isNoCacheEnabled(null)
@@ -62,6 +70,18 @@ class CacheControlInterceptorUnitSpec extends Specification {
 
     private static class ActionOptOut {
         @NoCacheOptOut
+        def index() {}
+
+        def other() {}
+    }
+
+    @NoCache
+    private static class ControllerNoCache {
+        def index() {}
+    }
+
+    private static class ActionNoCache {
+        @NoCache
         def index() {}
 
         def other() {}


### PR DESCRIPTION
- Add interceptor to apply no cache headers for all HTML pages, web services, etc
- Add additional support annotations for early commit and no cache opt out
- Explicitly disallow image actions from being no cached