### PR TITLE
S3 connection reliability updates

### DIFF
--- a/image-service/build.gradle
+++ b/image-service/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     // AWS SDK v2
     implementation platform("software.amazon.awssdk:bom:$awsSdk2Version")
     implementation "software.amazon.awssdk:apache-client"
+    implementation "software.amazon.awssdk:apache5-client"
     implementation "software.amazon.awssdk:cloudwatch-metric-publisher"
     implementation "software.amazon.awssdk:netty-nio-client"
     implementation "software.amazon.awssdk:aws-crt-client"
@@ -106,6 +107,13 @@ dependencies {
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:auth"
     implementation("software.amazon.awssdk.crt:aws-crt:0.47.3")
+
+    // AWS SDK requires Apache HTTP Client v5.6+ but Grails/Spring Boot pin it to 5.1, so force it here:
+    // TODO Review on Grails/Spring Boot/AWS SDK upgrades
+    implementation "org.apache.httpcomponents.client5:httpclient5:5.6.2"
+    implementation "org.apache.httpcomponents.core5:httpcore5:5.4.3"
+    implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
+
     // TEMP: Keep AWS SDK v1 during migration; remove once all code/tests are v2
 //    implementation "com.amazonaws:aws-java-sdk-s3:1.12.418"
     implementation 'org.javaswift:joss:0.10.4'

--- a/image-service/build.gradle
+++ b/image-service/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation "software.amazon.awssdk:s3-transfer-manager"
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:auth"
-    implementation("software.amazon.awssdk.crt:aws-crt:0.45.1")
+    implementation("software.amazon.awssdk.crt:aws-crt:0.47.3")
     // TEMP: Keep AWS SDK v1 during migration; remove once all code/tests are v2
 //    implementation "com.amazonaws:aws-java-sdk-s3:1.12.418"
     implementation 'org.javaswift:joss:0.10.4'

--- a/image-service/gradle.properties
+++ b/image-service/gradle.properties
@@ -7,5 +7,5 @@ grailsGradlePluginVersion=6.2.4
 gormVersion=8.0.0
 #groovyVersion=3.0.11
 #gorm.version=7.3.2
-awsSdk2Version=2.42.37
+awsSdk2Version=2.47.5
 alaSecurityLibsVersion=7.0.1

--- a/image-service/gradle.properties
+++ b/image-service/gradle.properties
@@ -7,5 +7,5 @@ grailsGradlePluginVersion=6.2.4
 gormVersion=8.0.0
 #groovyVersion=3.0.11
 #gorm.version=7.3.2
-awsSdk2Version=2.47.5
+awsSdk2Version=2.47.6
 alaSecurityLibsVersion=7.0.1

--- a/image-service/grails-app/conf/application.yml
+++ b/image-service/grails-app/conf/application.yml
@@ -324,6 +324,18 @@ imageservice:
     thumbnail:
         size: 300
 
+aws:
+    s3:
+        crt:
+            max-concurrency: 32 # transfer connections, not CRT event-loop threads
+            event-loop-threads: 0 # zero retains CRT defaults; must be set before CRT clients are created
+            future-completion-threads: 2
+            future-completion-queue-capacity: 256
+        application:
+            stream:
+                idle:
+                    timeout: 0 # seconds; zero disables the opt-in S3 application-stream idle watchdog
+
 serverName: 'http://devt.ala.org.au:8080'
 
 skin:

--- a/image-service/grails-app/services/au/org/ala/images/StorageOperationsRegistry.groovy
+++ b/image-service/grails-app/services/au/org/ala/images/StorageOperationsRegistry.groovy
@@ -11,6 +11,7 @@ import org.javaswift.joss.client.factory.AuthenticationMethod
 import org.springframework.beans.factory.annotation.Autowired
 
 import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -218,5 +219,23 @@ class StorageOperationsRegistry {
     boolean isInitialized() {
         return initialized
     }
-}
 
+    /**
+     * Releases instance-owned resources for configured storage operations at application shutdown.
+     * Role-specific S3 clients and transfer managers remain managed by their shared caches.
+     */
+    @PreDestroy
+    void destroy() {
+        operationsByName.values().each { StorageOperations operations ->
+            if (!(operations instanceof AutoCloseable)) {
+                return
+            }
+            try {
+                (operations as AutoCloseable).close()
+            } catch (Exception e) {
+                log.warn('Failed to close storage operations {}', operations, e)
+            }
+        }
+        S3StorageOperations.shutdownSharedResources()
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/S3ByteSinkFactory.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/S3ByteSinkFactory.groovy
@@ -1,6 +1,8 @@
 package au.org.ala.images
 
 import au.org.ala.images.metrics.MetricsTrackingOutputStream
+import au.org.ala.images.storage.S3ApplicationStreamIdleTimeoutException
+import au.org.ala.images.storage.S3ApplicationWatchdogOutputStream
 import au.org.ala.images.util.ByteSinkFactory
 import com.google.common.io.ByteSink
 import groovy.util.logging.Slf4j
@@ -15,11 +17,13 @@ import software.amazon.awssdk.services.s3.model.Tagging
 
 import java.nio.file.Files
 import java.time.Duration
+import grails.util.Holders
 
 @Slf4j
 class S3ByteSinkFactory implements ByteSinkFactory {
 
     static boolean streaming = Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.upload.streaming', 'true'))
+    private static final Duration applicationStreamIdleTimeout = applicationStreamIdleTimeout()
 
     private final S3AsyncClient s3Client
     private final S3TransferManager s3TransferManager
@@ -87,14 +91,22 @@ class S3ByteSinkFactory implements ByteSinkFactory {
                             .build()
                     def uploadFuture = s3TransferManager.upload(uploadReq).completionFuture()
 
-                    baseStream = new FilterOutputStream(blockingBody.outputStream()) {
+                    def outputStream = blockingBody.outputStream()
+                    S3ApplicationWatchdogOutputStream watchdogStream = applicationStreamIdleTimeout == null ? null :
+                            new S3ApplicationWatchdogOutputStream(outputStream, applicationStreamIdleTimeout, 'upload')
+                    baseStream = new FilterOutputStream(watchdogStream ?: outputStream) {
                         @Override
                         void close() throws IOException {
-                            super.close()
-                            // wait for the upload thread to finish
                             try {
+                                super.close()
+                                // Producer EOF is not terminal: retain the watchdog while the upload completes.
                                 uploadFuture.join()
+                                watchdogStream?.completed()
                             } catch (Exception e) {
+                                if (watchdogStream?.timedOut) {
+                                    throw watchdogStream.timeoutException(e)
+                                }
+                                watchdogStream?.failed()
                                 throw new IOException("S3 upload failed", e)
                             }
                         }
@@ -170,5 +182,14 @@ class S3ByteSinkFactory implements ByteSinkFactory {
                 return contentType
             }
         }
+    }
+    private static Duration applicationStreamIdleTimeout() {
+        int timeoutSeconds = Holders.getConfig().getProperty(
+                'aws.s3.application.stream.idle.timeout', Integer,
+                Integer.getInteger('au.org.ala.images.s3.application.stream.idle.timeout', 0))
+        if (timeoutSeconds < 0) {
+            throw new IllegalArgumentException('aws.s3.application.stream.idle.timeout must be zero or a positive number of seconds')
+        }
+        return timeoutSeconds == 0 ? null : Duration.ofSeconds(timeoutSeconds)
     }
 }

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationStreamIdleTimeoutException.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationStreamIdleTimeoutException.groovy
@@ -1,0 +1,19 @@
+package au.org.ala.images.storage
+
+import groovy.transform.CompileStatic
+
+/**
+ * Raised when an application-owned S3 stream makes no forward progress within
+ * the configured idle interval.
+ */
+@CompileStatic
+class S3ApplicationStreamIdleTimeoutException extends IOException {
+
+    S3ApplicationStreamIdleTimeoutException(String message) {
+        super(message)
+    }
+
+    S3ApplicationStreamIdleTimeoutException(String message, Throwable cause) {
+        super(message, cause)
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationStreamWatchdog.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationStreamWatchdog.groovy
@@ -1,0 +1,139 @@
+package au.org.ala.images.storage
+
+import groovy.transform.CompileStatic
+
+import java.time.Duration
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.function.LongSupplier
+
+@CompileStatic
+enum S3ApplicationStreamWatchdogState {
+    ACTIVE, TIMED_OUT, COMPLETED, CLOSED, FAILED
+}
+
+@CompileStatic
+interface S3ApplicationStreamWatchdogTask {
+    void cancel()
+}
+
+@CompileStatic
+interface S3ApplicationStreamWatchdogScheduler {
+    S3ApplicationStreamWatchdogTask schedule(Runnable task, long delayNanos)
+}
+
+/**
+ * One-shot, resettable idle watchdog.  The supplied cancellation action must
+ * unblock the operation that is currently waiting for application progress.
+ */
+@CompileStatic
+class S3ApplicationStreamWatchdog {
+
+    private final long timeoutNanos
+    private final LongSupplier nanoClock
+    private final S3ApplicationStreamWatchdogScheduler scheduler
+    private final Runnable timeoutAction
+
+    private S3ApplicationStreamWatchdogTask scheduledTask
+    private long deadlineNanos
+    private long generation
+    private S3ApplicationStreamWatchdogState state = S3ApplicationStreamWatchdogState.ACTIVE
+
+    S3ApplicationStreamWatchdog(Duration timeout, Runnable timeoutAction) {
+        this(timeout, System.&nanoTime as LongSupplier, new ExecutorScheduler(), timeoutAction)
+    }
+
+    S3ApplicationStreamWatchdog(Duration timeout, LongSupplier nanoClock,
+                                S3ApplicationStreamWatchdogScheduler scheduler, Runnable timeoutAction) {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException('S3 application stream idle timeout must be positive')
+        }
+        this.timeoutNanos = timeout.toNanos()
+        this.nanoClock = Objects.requireNonNull(nanoClock, 'nanoClock')
+        this.scheduler = Objects.requireNonNull(scheduler, 'scheduler')
+        this.timeoutAction = Objects.requireNonNull(timeoutAction, 'timeoutAction')
+        arm()
+    }
+
+    synchronized void progressed(long byteCount) {
+        if (byteCount <= 0 || state != S3ApplicationStreamWatchdogState.ACTIVE) {
+            return
+        }
+        arm()
+    }
+
+    synchronized void completed() {
+        terminate(S3ApplicationStreamWatchdogState.COMPLETED)
+    }
+
+    synchronized void closed() {
+        terminate(S3ApplicationStreamWatchdogState.CLOSED)
+    }
+
+    synchronized void failed() {
+        terminate(S3ApplicationStreamWatchdogState.FAILED)
+    }
+
+    synchronized S3ApplicationStreamWatchdogState getState() {
+        return state
+    }
+
+    private void arm() {
+        cancelScheduledTask()
+        deadlineNanos = nanoClock.getAsLong() + timeoutNanos
+        long armedGeneration = ++generation
+        scheduledTask = scheduler.schedule({ expire(armedGeneration) } as Runnable, timeoutNanos)
+    }
+
+    private void expire(long callbackGeneration) {
+        Runnable action = null
+        synchronized (this) {
+            if (state != S3ApplicationStreamWatchdogState.ACTIVE || callbackGeneration != generation) {
+                return
+            }
+            long remainingNanos = deadlineNanos - nanoClock.getAsLong()
+            if (remainingNanos > 0) {
+                scheduledTask = scheduler.schedule({ expire(callbackGeneration) } as Runnable, remainingNanos)
+                return
+            }
+            state = S3ApplicationStreamWatchdogState.TIMED_OUT
+            cancelScheduledTask()
+            action = timeoutAction
+        }
+        try {
+            action.run()
+        } catch (Throwable ignored) {
+            // The blocked caller receives the timeout after its cancellation action unblocks it.
+        }
+    }
+
+    private void terminate(S3ApplicationStreamWatchdogState terminalState) {
+        if (state != S3ApplicationStreamWatchdogState.ACTIVE) {
+            return
+        }
+        state = terminalState
+        ++generation
+        cancelScheduledTask()
+    }
+
+    private void cancelScheduledTask() {
+        scheduledTask?.cancel()
+        scheduledTask = null
+    }
+
+    @CompileStatic
+    private static class ExecutorScheduler implements S3ApplicationStreamWatchdogScheduler {
+        private static final ScheduledExecutorService executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor({ Runnable runnable ->
+            Thread thread = new Thread(runnable, 's3-application-stream-watchdog')
+            thread.daemon = true
+            return thread
+        } as java.util.concurrent.ThreadFactory)
+
+        @Override
+        S3ApplicationStreamWatchdogTask schedule(Runnable task, long delayNanos) {
+            ScheduledFuture<?> future = executor.schedule(task, delayNanos, TimeUnit.NANOSECONDS)
+            return { future.cancel(false) } as S3ApplicationStreamWatchdogTask
+        }
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationWatchdogInputStream.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationWatchdogInputStream.groovy
@@ -1,0 +1,88 @@
+package au.org.ala.images.storage
+
+import groovy.transform.CompileStatic
+import software.amazon.awssdk.core.ResponseInputStream
+
+import java.time.Duration
+
+/**
+ * Owns an application-level idle deadline for an SDK async blocking response.
+ * It is intentionally limited to ResponseInputStream so abort can cancel the
+ * SDK subscription that is servicing a blocked application read.
+ */
+@CompileStatic
+class S3ApplicationWatchdogInputStream<ResponseT> extends FilterInputStream {
+
+    private final ResponseInputStream<ResponseT> responseInputStream
+    private final S3ApplicationStreamWatchdog watchdog
+    private final String description
+
+    S3ApplicationWatchdogInputStream(ResponseInputStream<ResponseT> responseInputStream, Duration idleTimeout, String description) {
+        super(Objects.requireNonNull(responseInputStream, 'responseInputStream'))
+        this.responseInputStream = responseInputStream
+        this.description = Objects.requireNonNull(description, 'description')
+        watchdog = new S3ApplicationStreamWatchdog(idleTimeout, { responseInputStream.abort() } as Runnable)
+    }
+
+    boolean isTimedOut() { watchdog.state == S3ApplicationStreamWatchdogState.TIMED_OUT }
+
+    S3ApplicationStreamIdleTimeoutException timeoutException(Throwable cause = null) {
+        new S3ApplicationStreamIdleTimeoutException("S3 application stream was idle while reading ${description}", cause)
+    }
+
+    @Override
+    int read() throws IOException {
+        readWithProgress({ super.read() } as ReadOperation)
+    }
+
+    @Override
+    int read(byte[] bytes) throws IOException {
+        readWithProgress({ super.read(bytes) } as ReadOperation)
+    }
+
+    @Override
+    int read(byte[] bytes, int offset, int length) throws IOException {
+        readWithProgress({ super.read(bytes, offset, length) } as ReadOperation)
+    }
+
+    @Override
+    void close() throws IOException {
+        try {
+            super.close()
+        } catch (Throwable exception) {
+            throw timeoutOr(exception)
+        } finally {
+            watchdog.closed()
+        }
+    }
+
+    private int readWithProgress(ReadOperation operation) throws IOException {
+        try {
+            int count = operation.read()
+            if (count < 0) {
+                watchdog.completed()
+            } else {
+                watchdog.progressed(count == 0 ? 0 : count)
+            }
+            return count
+        } catch (Throwable exception) {
+            throw timeoutOr(exception)
+        }
+    }
+
+    private IOException timeoutOr(Throwable exception) {
+        if (isTimedOut()) {
+            return timeoutException(exception)
+        }
+        watchdog.failed()
+        if (exception instanceof IOException) {
+            return exception as IOException
+        }
+        return new IOException("S3 application stream failed while reading ${description}", exception)
+    }
+
+    @CompileStatic
+    private static interface ReadOperation {
+        int read() throws IOException
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationWatchdogOutputStream.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3ApplicationWatchdogOutputStream.groovy
@@ -1,0 +1,66 @@
+package au.org.ala.images.storage
+
+import groovy.transform.CompileStatic
+import software.amazon.awssdk.utils.CancellableOutputStream
+
+import java.time.Duration
+
+/** Output stream wrapper for the SDK boundary that documents cancellation support. */
+@CompileStatic
+class S3ApplicationWatchdogOutputStream extends FilterOutputStream {
+
+    private final S3ApplicationStreamWatchdog watchdog
+    private final String description
+
+    S3ApplicationWatchdogOutputStream(CancellableOutputStream delegate, Duration idleTimeout, String description) {
+        super(delegate)
+        this.description = description
+        watchdog = new S3ApplicationStreamWatchdog(idleTimeout, { delegate.cancel() } as Runnable)
+    }
+
+    void completed() { watchdog.completed() }
+    void failed() { watchdog.failed() }
+
+    boolean isTimedOut() { watchdog.state == S3ApplicationStreamWatchdogState.TIMED_OUT }
+
+    S3ApplicationStreamIdleTimeoutException timeoutException(Throwable cause = null) {
+        return new S3ApplicationStreamIdleTimeoutException("S3 application stream was idle while writing ${description}", cause)
+    }
+
+    @Override
+    void write(int value) throws IOException {
+        try {
+            super.write(value)
+            watchdog.progressed(1)
+        } catch (IOException exception) {
+            throw timeoutOr(exception)
+        }
+    }
+
+    @Override
+    void write(byte[] bytes, int offset, int length) throws IOException {
+        try {
+            super.write(bytes, offset, length)
+            watchdog.progressed(length)
+        } catch (IOException exception) {
+            throw timeoutOr(exception)
+        }
+    }
+
+    @Override
+    void close() throws IOException {
+        try {
+            super.close()
+        } catch (IOException exception) {
+            throw timeoutOr(exception)
+        }
+    }
+
+    private IOException timeoutOr(IOException exception) {
+        if (watchdog.state == S3ApplicationStreamWatchdogState.TIMED_OUT) {
+            return timeoutException(exception)
+        }
+        watchdog.failed()
+        return exception
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3CrtSafeguards.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3CrtSafeguards.groovy
@@ -1,0 +1,85 @@
+package au.org.ala.images.storage
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+import java.util.function.IntConsumer
+import java.util.function.IntSupplier
+import java.util.function.Function
+
+/** Pure CRT safeguards kept separate from S3 client and CRT global initialization. */
+class S3CrtSafeguards {
+
+    static int requirePositive(String property, int value) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("${property} must be a positive integer")
+        }
+        return value
+    }
+
+    static int requireNonNegative(String property, int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("${property} must be zero or a positive integer")
+        }
+        return value
+    }
+
+    static boolean applyBootstrapIfEligible(int eventLoopThreads, boolean clientAlreadyCreated, Runnable setStaticDefault) {
+        if (eventLoopThreads == 0 || clientAlreadyCreated) {
+            return false
+        }
+        setStaticDefault.run()
+        return true
+    }
+
+    /** Resolves the Grails configuration boundary lazily, with a system-property fallback. */
+    static int resolveConfiguredEventLoopThreads(Function<String, Integer> configuredValue, IntSupplier systemFallback) {
+        Integer configuredThreads = configuredValue.apply('aws.s3.crt.event-loop-threads')
+        int eventLoopThreads = configuredThreads != null ? configuredThreads : systemFallback.asInt
+        return requireNonNegative('aws.s3.crt.event-loop-threads', eventLoopThreads)
+    }
+
+    /** Applies an already-resolved configuration value immediately before CRT client construction. */
+    static boolean applyConfiguredBootstrap(IntSupplier configuredThreads, boolean clientAlreadyCreated,
+                                            IntConsumer setStaticDefault) {
+        if (clientAlreadyCreated) {
+            return false
+        }
+        int eventLoopThreads = configuredThreads.asInt
+        if (eventLoopThreads == 0) {
+            return false
+        }
+        setStaticDefault.accept(eventLoopThreads)
+        return true
+    }
+
+    static ThreadPoolExecutor newCompletionExecutor(int threads, int queueCapacity) {
+        int validatedThreads = requirePositive('aws.s3.crt.future-completion-threads', threads)
+        int validatedQueueCapacity = requirePositive('aws.s3.crt.future-completion-queue-capacity', queueCapacity)
+        return new ThreadPoolExecutor(
+                validatedThreads, validatedThreads, 0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<Runnable>(validatedQueueCapacity),
+                { Runnable runnable -> new Thread(runnable, 's3-crt-future-completion-test') } as ThreadFactory,
+                { Runnable task, ThreadPoolExecutor executor ->
+                    throw new RejectedExecutionException('S3 CRT future-completion executor is saturated')
+                } as java.util.concurrent.RejectedExecutionHandler)
+    }
+
+    static void scheduleEvictedResourceClose(AutoCloseable resource, ScheduledExecutorService scheduler, long delay, TimeUnit unit) {
+        scheduler.schedule({
+            try {
+                resource?.close()
+            } catch (Exception ignored) {
+                // Cache eviction must not prevent other queued resource closes.
+            }
+        }, delay, unit)
+    }
+
+    static void configureMaxConcurrency(int maxConcurrency, Consumer<Integer> configure) {
+        configure.accept(requirePositive('aws.s3.crt.max-concurrency', maxConcurrency))
+    }
+}

--- a/image-service/src/main/groovy/au/org/ala/images/storage/S3StorageOperations.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/storage/S3StorageOperations.groovy
@@ -56,6 +56,7 @@ import software.amazon.awssdk.core.async.BlockingOutputStreamAsyncRequestBody
 import software.amazon.awssdk.transfer.s3.model.UploadRequest
 import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.services.s3.model.*
 
 import java.time.Duration
@@ -63,8 +64,16 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.function.Function
 import java.util.function.Consumer
+import java.util.function.IntConsumer
+import java.util.function.IntSupplier
 import java.util.concurrent.CountDownLatch
 
 import com.google.common.annotations.VisibleForTesting
@@ -77,7 +86,7 @@ import org.apache.commons.io.FilenameUtils
 @CompileStatic
 @Slf4j
 @EqualsAndHashCode(includes = ['region', 'bucket', 'prefix'])
-class S3StorageOperations implements StorageOperations {
+class S3StorageOperations implements StorageOperations, AutoCloseable {
 
     String region
     String bucket
@@ -107,6 +116,15 @@ class S3StorageOperations implements StorageOperations {
     private Counter s3OperationErrorCounter
     private Counter s3OperationSuccessCounter
 
+    /**
+     * Test seam for observing the client used to construct a transfer manager.
+     * Production instances leave this unset and use the shared cache below.
+     */
+    @VisibleForTesting
+    private Function<S3AsyncClient, S3TransferManager> transferManagerFactoryForTesting
+
+    private volatile S3TransferManager legacyS3TransferManager
+
     private static final int maxConnections = Holders.getConfig().getProperty('aws.s3.max.connections', Integer, Integer.getInteger('au.org.ala.images.s3.max.connections', 500))
     private static final int maxErrorRetry = Holders.getConfig().getProperty('aws.s3.max.retry', Integer, Integer.getInteger('au.org.ala.images.s3.max.retry', 3))
     private static final int apiCallAttemptTimeout = Holders.getConfig().getProperty('aws.s3.timeouts.attempt', Integer, Integer.getInteger('au.org.ala.images.s3.timeouts.attempt', 5))
@@ -125,6 +143,11 @@ class S3StorageOperations implements StorageOperations {
     // to quickly detect a connection that has stalled after TCP establishment.
     private static final long crtThroughputBps = Holders.getConfig().getProperty('aws.s3.crt.throughput.bps', Long, Long.getLong('au.org.ala.images.s3.crt.throughput.bps', 32 * 1024))
     private static final int crtConnectionTimeout = Holders.getConfig().getProperty('aws.s3.crt.connection.timeout', Integer, Integer.getInteger('au.org.ala.images.s3.crt.connection.timeout', 2))
+    // This limits S3 transfer connections; it does not configure CRT event-loop threads.
+    private static final int crtMaxConcurrency = positiveConfig('aws.s3.crt.max-concurrency', 'au.org.ala.images.s3.crt.max-concurrency', 32)
+    private static final int crtCompletionThreads = positiveConfig('aws.s3.crt.future-completion-threads', 'au.org.ala.images.s3.crt.future-completion-threads', 2)
+    private static final int crtCompletionQueueCapacity = positiveConfig('aws.s3.crt.future-completion-queue-capacity', 'au.org.ala.images.s3.crt.future-completion-queue-capacity', 256)
+    private static final Duration applicationStreamIdleTimeout = optionalPositiveDuration('aws.s3.application.stream.idle.timeout', 'au.org.ala.images.s3.application.stream.idle.timeout')
     private static final boolean publishCloudwatchMetrics = Holders.getConfig().getProperty('aws.s3.cloudwatch.metrics.enabled', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.cloudwatch.metrics.enabled', 'false')))
     private static final String cloudWatchNamespace = Holders.getConfig().getProperty('aws.s3.cloudwatch.metrics.namespace', String, System.getProperty('au.org.ala.images.s3.cloudwatch.metrics.namespace', 'au.org.ala.image-service/S3'))
     private static final boolean forceAsyncCalls = Holders.getConfig().getProperty('aws.s3.force.async', Boolean, Boolean.parseBoolean(System.getProperty('au.org.ala.images.s3.force.async', 'false')))
@@ -137,6 +160,23 @@ class S3StorageOperations implements StorageOperations {
             daemon = true
         }
     } as ThreadFactory)
+
+    private static final ThreadPoolExecutor crtFutureCompletionExecutor = new ThreadPoolExecutor(
+            crtCompletionThreads, crtCompletionThreads, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<Runnable>(crtCompletionQueueCapacity), { Runnable runnable ->
+                new Thread(runnable, 's3-crt-future-completion').tap { daemon = true }
+            } as ThreadFactory,
+            { Runnable task, ThreadPoolExecutor executor ->
+                long rejected = crtCompletionRejections.incrementAndGet()
+                log.warn('Rejected CRT future-completion callback because the bounded executor is saturated (count={})', rejected)
+                throw new RejectedExecutionException('S3 CRT future-completion executor is saturated')
+            } as java.util.concurrent.RejectedExecutionHandler)
+    private static final Object crtBootstrapLock = new Object()
+    private static boolean crtClientCreated = false
+    private static final AtomicBoolean lateCrtBootstrapWarningLogged = new AtomicBoolean()
+    private static final AtomicBoolean legacyOverrideWarningLogged = new AtomicBoolean()
+    private static final AtomicBoolean sharedResourcesClosed = new AtomicBoolean()
+    private static final AtomicLong crtCompletionRejections = new AtomicLong()
 
     private static final MetricPublisher sharedMetricPublisher
     static {
@@ -187,15 +227,29 @@ class S3StorageOperations implements StorageOperations {
         return s3AsyncClientCacheLoader(key, true)
     }
 
-    private static final LoadingCache<CacheKey, S3AsyncClient> s3AsyncClientCache = Caffeine<String, S3AsyncClient>.from(asyncCacheSpec).removalListener {
+    private static final LoadingCache<CacheKey, S3AsyncClient> s3DownloadAsyncClientCache = Caffeine<String, S3AsyncClient>.from(asyncCacheSpec).removalListener {
         CacheKey key, S3AsyncClient client, RemovalCause cause ->
-            log.info("S3AsyncClient evicted from cache: ${key.bucket}")
-            s3TransferManagerCache.invalidate(key) // also remove any associated transfer manager
+            log.info("S3 download client evicted from cache: ${key.bucket}")
             evictionScheduler.schedule( {
                 try {
                     client?.close()
                 } catch (Exception e) {
-                    log.warn("Failed to close evicted S3AsyncClient", e)
+                    log.warn("Failed to close evicted S3 download client", e)
+                }
+            }, inflightTimeout, TimeUnit.SECONDS)
+    }.build { CacheKey key ->
+        return s3AsyncClientCacheLoader(key)
+    }
+
+    private static final LoadingCache<CacheKey, S3AsyncClient> s3UploadAsyncClientCache = Caffeine<String, S3AsyncClient>.from(asyncCacheSpec).removalListener {
+        CacheKey key, S3AsyncClient client, RemovalCause cause ->
+            log.info("S3 upload client evicted from cache: ${key.bucket}")
+            s3TransferManagerCache.invalidate(key)
+            evictionScheduler.schedule( {
+                try {
+                    client?.close()
+                } catch (Exception e) {
+                    log.warn("Failed to close evicted S3 upload client", e)
                 }
             }, inflightTimeout, TimeUnit.SECONDS)
     }.build { CacheKey key ->
@@ -218,9 +272,113 @@ class S3StorageOperations implements StorageOperations {
 
     static final void clearS3ClientCache() {
         s3TransferManagerCache.invalidateAll()
-        s3AsyncClientCache.invalidateAll()
+        s3DownloadAsyncClientCache.invalidateAll()
+        s3UploadAsyncClientCache.invalidateAll()
         smallS3AsyncClientCache.invalidateAll()
         s3ClientCache.invalidateAll()
+    }
+
+    /**
+     * Closes application-owned shared S3 resources during application shutdown.
+     * Cache eviction deliberately does not call this method because cached CRT
+     * clients share the completion executor.
+     */
+    static void shutdownSharedResources() {
+        if (!sharedResourcesClosed.compareAndSet(false, true)) {
+            return
+        }
+        closeAll(s3TransferManagerCache.asMap().values())
+        closeAll(s3DownloadAsyncClientCache.asMap().values())
+        closeAll(s3UploadAsyncClientCache.asMap().values())
+        closeAll(smallS3AsyncClientCache.asMap().values())
+        closeAll(s3ClientCache.asMap().values())
+        clearS3ClientCache()
+        crtFutureCompletionExecutor.shutdown()
+    }
+
+    private static void closeAll(Collection<? extends AutoCloseable> resources) {
+        resources.each { AutoCloseable resource ->
+            try {
+                resource?.close()
+            } catch (Exception exception) {
+                log.warn('Failed to close shared S3 resource during application shutdown', exception)
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static long getCrtCompletionRejectionCount() {
+        return crtCompletionRejections.get()
+    }
+
+    private static int positiveConfig(String property, String systemProperty, int defaultValue) {
+        int value = Holders.getConfig().getProperty(property, Integer, Integer.getInteger(systemProperty, defaultValue))
+        return S3CrtSafeguards.requirePositive(property, value)
+    }
+
+    @VisibleForTesting
+    static int requirePositiveConfig(String property, int value) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("${property} must be a positive integer")
+        }
+        return value
+    }
+
+    private static int nonNegativeConfig(String property, String systemProperty, int defaultValue) {
+        int value = Holders.getConfig().getProperty(property, Integer, Integer.getInteger(systemProperty, defaultValue))
+        return S3CrtSafeguards.requireNonNegative(property, value)
+    }
+
+    @VisibleForTesting
+    static int requireNonNegativeConfig(String property, int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("${property} must be zero or a positive integer")
+        }
+        return value
+    }
+
+    private static Duration optionalPositiveDuration(String property, String systemProperty) {
+        int seconds = nonNegativeConfig(property, systemProperty, 0)
+        return seconds == 0 ? null : Duration.ofSeconds(seconds)
+    }
+
+    /**
+     * Reads configuration only at the CRT client-construction boundary, after Grails has started.
+     * CRT owns this setting globally, so the first CRT client fixes the value for this JVM.
+     */
+    private static int resolveConfiguredCrtEventLoopThreads() {
+        return S3CrtSafeguards.resolveConfiguredEventLoopThreads(
+                { String property -> Holders.getConfig().getProperty(property, Integer, null) } as Function<String, Integer>,
+                { -> Integer.getInteger('au.org.ala.images.s3.crt.event-loop-threads', 0) } as IntSupplier)
+    }
+
+    @VisibleForTesting
+    static ThreadPoolExecutor newCrtFutureCompletionExecutor(int threads, int queueCapacity) {
+        int validatedThreads = requirePositiveConfig('aws.s3.crt.future-completion-threads', threads)
+        int validatedQueueCapacity = requirePositiveConfig('aws.s3.crt.future-completion-queue-capacity', queueCapacity)
+        return new ThreadPoolExecutor(
+                validatedThreads, validatedThreads, 0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<Runnable>(validatedQueueCapacity),
+                { Runnable runnable -> new Thread(runnable, 's3-crt-future-completion-test') } as ThreadFactory,
+                { Runnable task, ThreadPoolExecutor executor ->
+                    throw new RejectedExecutionException('S3 CRT future-completion executor is saturated')
+                } as java.util.concurrent.RejectedExecutionHandler)
+    }
+
+    @VisibleForTesting
+    static void scheduleEvictedResourceClose(AutoCloseable resource, ScheduledExecutorService scheduler, long delay, TimeUnit unit) {
+        scheduler.schedule({
+            try {
+                resource?.close()
+            } catch (Exception exception) {
+                log.warn('Failed to close evicted S3 resource', exception)
+            }
+        }, delay, unit)
+    }
+
+    @VisibleForTesting
+    static void configureCrtMaxConcurrency(int maxConcurrency, Consumer<Integer> configure) {
+        configure.accept(requirePositiveConfig('aws.s3.crt.max-concurrency', maxConcurrency))
     }
 
     @TupleConstructor
@@ -321,14 +479,70 @@ class S3StorageOperations implements StorageOperations {
 
     @VisibleForTesting
     protected S3AsyncClient getSmallS3AsyncClient() {
+        if (hasLegacyAsyncClientOverride()) {
+            return getS3AsyncClient()
+        }
+        return getDefaultSmallS3AsyncClient()
+    }
+
+    @VisibleForTesting
+    protected S3AsyncClient getS3DownloadAsyncClient() {
+        if (hasLegacyAsyncClientOverride()) {
+            return getS3AsyncClient()
+        }
+        return getDefaultS3DownloadAsyncClient()
+    }
+
+    @VisibleForTesting
+    protected S3AsyncClient getS3UploadAsyncClient() {
+        if (hasLegacyAsyncClientOverride()) {
+            return getS3AsyncClient()
+        }
+        return getDefaultS3UploadAsyncClient()
+    }
+
+    /**
+     * Legacy extension point retained for subclasses that supply one async client for all S3 work.
+     *
+     * New code must override one of the role-specific methods instead. Production instances use
+     * separate download and upload clients; an override of this method is intentionally treated as
+     * an opt-in to the legacy single-client behaviour for that subclass.
+     */
+    @Deprecated
+    @VisibleForTesting
+    protected S3AsyncClient getS3AsyncClient() {
+        return getDefaultS3DownloadAsyncClient()
+    }
+
+    private S3AsyncClient getDefaultSmallS3AsyncClient() {
         final cacheKey = getCacheKeyObject()
         return smallS3AsyncClientCache.get(cacheKey)
     }
 
-    @VisibleForTesting
-    protected S3AsyncClient getS3AsyncClient() {
+    private S3AsyncClient getDefaultS3DownloadAsyncClient() {
         final cacheKey = getCacheKeyObject()
-        return s3AsyncClientCache.get(cacheKey)
+        return s3DownloadAsyncClientCache.get(cacheKey)
+    }
+
+    private S3AsyncClient getDefaultS3UploadAsyncClient() {
+        final cacheKey = getCacheKeyObject()
+        return s3UploadAsyncClientCache.get(cacheKey)
+    }
+
+    private boolean hasLegacyAsyncClientOverride() {
+        Class<?> candidate = getClass()
+        while (candidate != null && candidate != S3StorageOperations) {
+            try {
+                candidate.getDeclaredMethod('getS3AsyncClient')
+                if (legacyOverrideWarningLogged.compareAndSet(false, true)) {
+                    log.warn('Using legacy getS3AsyncClient override; download, upload, and small S3 operations share one subclass-owned client')
+                }
+                return true
+            } catch (NoSuchMethodException ignored) {
+                candidate = candidate.getSuperclass()
+            }
+        }
+        return false
     }
 
     private static S3AsyncClient s3AsyncClientCacheLoader(CacheKey key, boolean smallOps = false) {
@@ -383,7 +597,6 @@ class S3StorageOperations implements StorageOperations {
             client = builder.build()
         } else {
             log.info("Using CRT S3AsyncClient builder for S3 access")
-
             def builder = S3AsyncClient.crtBuilder()
                     .httpConfiguration(
                             S3CrtHttpConfiguration.builder()
@@ -397,7 +610,9 @@ class S3StorageOperations implements StorageOperations {
                     )
                     .credentialsProvider(credProvider)
                     .retryConfiguration(S3CrtRetryConfiguration.builder().numRetries(maxErrorRetry).build())
-//                        .maxConcurrency(maxConnections)
+                    .futureCompletionExecutor(crtFutureCompletionExecutor)
+
+            S3CrtSafeguards.configureMaxConcurrency(crtMaxConcurrency, { int concurrency -> builder.maxConcurrency(concurrency) } as Consumer<Integer>)
 
             if (region) {
                 builder = builder.region(Region.of(region))
@@ -408,23 +623,88 @@ class S3StorageOperations implements StorageOperations {
             if (pathStyleAccess) {
                 builder = builder.forcePathStyle(pathStyleAccess)
             }
-            client = builder.build()
+            synchronized (crtBootstrapLock) {
+                int configuredEventLoopThreads = resolveConfiguredCrtEventLoopThreads()
+                boolean initialized = S3CrtSafeguards.applyConfiguredBootstrap(
+                        { -> configuredEventLoopThreads } as IntSupplier,
+                        crtClientCreated,
+                        { int configuredThreads ->
+                            software.amazon.awssdk.crt.io.EventLoopGroup.setStaticDefaultNumThreads(configuredThreads)
+                        } as IntConsumer)
+                if (initialized) {
+                    log.info('Configured CRT static default event-loop group with {} thread(s)', configuredEventLoopThreads)
+                } else if (crtClientCreated && lateCrtBootstrapWarningLogged.compareAndSet(false, true)) {
+                    log.warn('A CRT client already exists; retaining its process-wide event-loop thread setting')
+                }
+                client = builder.build()
+                crtClientCreated = true
+            }
         }
         return client
     }
 
     @VisibleForTesting
     protected S3TransferManager getS3TransferManager() {
+        final Function<S3AsyncClient, S3TransferManager> factory = transferManagerFactoryForTesting
+        if (hasLegacyAsyncClientOverride()) {
+            return getLegacyS3TransferManager(factory)
+        }
+        if (factory != null) {
+            return factory.apply(getS3UploadAsyncClient())
+        }
         final cacheKey = getCacheKeyObject()
         // Ensure the underlying AsyncClient is kept alive in the cache whenever the TransferManager is requested
 //        getS3AsyncClient(cacheKey)
         return s3TransferManagerCache.get(cacheKey)
     }
 
+    private S3TransferManager getLegacyS3TransferManager(Function<S3AsyncClient, S3TransferManager> factory) {
+        S3TransferManager manager = legacyS3TransferManager
+        if (manager != null) {
+            return manager
+        }
+
+        synchronized (this) {
+            if (legacyS3TransferManager == null) {
+                final S3AsyncClient asyncClient = getS3UploadAsyncClient()
+                legacyS3TransferManager = factory != null
+                        ? factory.apply(asyncClient)
+                        : S3TransferManager.builder().s3Client(asyncClient).build()
+            }
+            return legacyS3TransferManager
+        }
+    }
+
+    /**
+     * Releases the transfer manager owned by the legacy single-async-client compatibility path.
+     * The async client belongs to the overriding subclass and is deliberately not closed here.
+     */
+    @Override
+    void close() {
+        final S3TransferManager manager
+        synchronized (this) {
+            manager = legacyS3TransferManager
+            legacyS3TransferManager = null
+        }
+        if (manager == null) {
+            return
+        }
+        try {
+            manager.close()
+        } catch (Exception e) {
+            log.warn('Failed to close legacy S3TransferManager', e)
+        }
+    }
+
+    @VisibleForTesting
+    void setTransferManagerFactoryForTesting(Function<S3AsyncClient, S3TransferManager> factory) {
+        transferManagerFactoryForTesting = factory
+    }
+
     private static S3TransferManager s3TransferManagerCacheLoader(CacheKey key) {
         log.info("Creating S3TransferManager for bucket: ${key.bucket} in region: ${key.region ?: 'default'}")
 
-        def s3AsyncClient = s3AsyncClientCache.get(key)
+        def s3AsyncClient = s3UploadAsyncClientCache.get(key)
         return S3TransferManager.builder()
                 .s3Client(s3AsyncClient)
                 .build()
@@ -640,7 +920,7 @@ class S3StorageOperations implements StorageOperations {
                 }
             } as Consumer<V2GetObjectRequest.Builder>
             if (isUseAsyncS3Client()) {
-                def resp = s3AsyncClient.getObject(consumer, AsyncResponseTransformer.toBytes()).join()
+                def resp = s3DownloadAsyncClient.getObject(consumer, AsyncResponseTransformer.toBytes()).join()
                 return resp.asByteArray()
             } else {
                 def s3Object = s3Client.getObject(consumer)
@@ -835,9 +1115,11 @@ class S3StorageOperations implements StorageOperations {
 
             InputStream rawStream
             if (isUseAsyncS3Client()) {
-                rawStream = s3AsyncClient
+                ResponseInputStream<GetObjectResponse> responseStream = s3DownloadAsyncClient
                         .getObject(consumer, AsyncResponseTransformer.toBlockingInputStream())
                         .join()
+                rawStream = applicationStreamIdleTimeout == null ? responseStream :
+                        new S3ApplicationWatchdogInputStream<GetObjectResponse>(responseStream, applicationStreamIdleTimeout, path)
             } else {
                 rawStream = s3Client.getObject(consumer)
             }
@@ -1006,7 +1288,7 @@ class S3StorageOperations implements StorageOperations {
     }
 
     ByteSinkFactory byteSinkFactory(String uuid, Map<String, String> tags, String... prefixes) {
-        return new S3ByteSinkFactory(s3AsyncClient, s3TransferManager, apiCallTimeout, storagePathStrategy(), bucket, uuid, tags, meterRegistry, region, prefixes)
+        return new S3ByteSinkFactory(s3UploadAsyncClient, s3TransferManager, apiCallTimeout, storagePathStrategy(), bucket, uuid, tags, meterRegistry, region, prefixes)
     }
 
     @Override
@@ -1079,11 +1361,15 @@ class S3StorageOperations implements StorageOperations {
             InputStream objectStream
             if (isUseAsyncS3Client()) {
                 def consumer = { V2GetObjectRequest.Builder b -> b.bucket(bkt).key(k) } as Consumer<V2GetObjectRequest.Builder>
-                objectStream = s3AsyncClient.getObject(consumer, AsyncResponseTransformer.toBlockingInputStream()).join()
+                ResponseInputStream<GetObjectResponse> responseStream = s3DownloadAsyncClient.getObject(consumer, AsyncResponseTransformer.toBlockingInputStream()).join()
+                objectStream = applicationStreamIdleTimeout == null ? responseStream :
+                        new S3ApplicationWatchdogInputStream<GetObjectResponse>(responseStream, applicationStreamIdleTimeout, k)
             } else {
                 objectStream = s3Client.getObject({ V2GetObjectRequest.Builder b -> b.bucket(bkt).key(k) } as Consumer<V2GetObjectRequest.Builder>)
             }
-            destination.storeAnywhere(uuid, objectStream, k - basePath, head.contentType(), head.contentDisposition(), (obj['size'] as long))
+            objectStream.withCloseable {
+                destination.storeAnywhere(uuid, it, k - basePath, head.contentType(), head.contentDisposition(), (obj['size'] as long))
+            }
         }
     }
 

--- a/image-service/src/test/groovy/au/org/ala/images/S3ByteSinkFactorySpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/S3ByteSinkFactorySpec.groovy
@@ -1,0 +1,59 @@
+package au.org.ala.images
+
+import au.org.ala.images.storage.S3ApplicationWatchdogOutputStream
+import au.org.ala.images.storage.S3ApplicationStreamIdleTimeoutException
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class S3ByteSinkFactorySpec extends Specification {
+
+    def 'SDK cancellable output stream unblocks a blocked write after the idle timeout'() {
+        given:
+        def delegate = new CancellableBlockedOutputStream()
+        def stream = new S3ApplicationWatchdogOutputStream(delegate, Duration.ofMillis(50), 'upload')
+        def result = new AtomicReference<Throwable>()
+        def writer = Thread.start {
+            try {
+                stream.write(1)
+            } catch (Throwable error) {
+                result.set(error)
+            }
+        }
+
+        expect: 'the named write boundary is blocked before cancellation'
+        delegate.writeStarted.await(5, TimeUnit.SECONDS)
+
+        when:
+        writer.join(5_000)
+
+        then:
+        !writer.alive
+        delegate.cancelled.await(5, TimeUnit.SECONDS)
+        stream.timedOut
+        result.get() instanceof S3ApplicationStreamIdleTimeoutException
+
+        cleanup:
+        stream.close()
+    }
+
+    private static class CancellableBlockedOutputStream extends software.amazon.awssdk.utils.CancellableOutputStream {
+        final CountDownLatch writeStarted = new CountDownLatch(1)
+        final CountDownLatch cancelled = new CountDownLatch(1)
+
+        @Override
+        void write(int value) throws IOException {
+            writeStarted.countDown()
+            cancelled.await()
+            throw new IOException('cancelled')
+        }
+
+        @Override
+        void cancel() {
+            cancelled.countDown()
+        }
+    }
+}

--- a/image-service/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/S3StorageOperationsSpec.groovy
@@ -3,6 +3,7 @@ package au.org.ala.images
 import au.org.ala.images.storage.S3StorageOperations
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.core.ResponseBytes
+import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
@@ -18,14 +19,18 @@ import software.amazon.awssdk.services.s3.model.PutObjectAclRequest
 import software.amazon.awssdk.services.s3.model.PutObjectResponse
 import software.amazon.awssdk.services.s3.model.S3Object
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import software.amazon.awssdk.transfer.s3.model.CompletedUpload
 import software.amazon.awssdk.transfer.s3.model.Upload
 import software.amazon.awssdk.transfer.s3.model.UploadRequest
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
+import java.util.function.Function
 import grails.testing.gorm.DataTest
 import groovy.util.logging.Slf4j
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import spock.lang.Specification
 
 @Slf4j
@@ -38,7 +43,8 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
     private static class TestOps extends S3StorageOperations {
         S3Client mockClient
         S3AsyncClient mockSmallAsyncClient
-        S3AsyncClient mockAsyncClient
+        S3AsyncClient mockDownloadAsyncClient
+        S3AsyncClient mockUploadAsyncClient
         S3TransferManager mockTransferManager
         boolean forceAsync = false
 
@@ -49,13 +55,27 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
         protected S3AsyncClient getSmallS3AsyncClient() { return mockSmallAsyncClient }
 
         @Override
-        protected S3AsyncClient getS3AsyncClient() { return mockAsyncClient }
+        protected S3AsyncClient getS3DownloadAsyncClient() { return mockDownloadAsyncClient }
 
         @Override
-        protected S3TransferManager getS3TransferManager() { return mockTransferManager }
+        protected S3AsyncClient getS3UploadAsyncClient() { return mockUploadAsyncClient }
+
+        @Override
+        protected S3TransferManager getS3TransferManager() { return mockTransferManager ?: super.getS3TransferManager() }
 
         @Override
         protected boolean isUseAsyncS3Client() { return forceAsync }
+    }
+
+    private static class LegacyAsyncClientOps extends S3StorageOperations {
+        S3AsyncClient legacyAsyncClient
+
+        @Override
+        protected S3AsyncClient getS3AsyncClient() { return legacyAsyncClient }
+
+        S3AsyncClient smallAsyncClient() { return getSmallS3AsyncClient() }
+        S3AsyncClient downloadAsyncClient() { return getS3DownloadAsyncClient() }
+        S3AsyncClient uploadAsyncClient() { return getS3UploadAsyncClient() }
     }
 
     private void consumeBody(UploadRequest req) {
@@ -65,6 +85,22 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
             @Override void onError(Throwable t) {}
             @Override void onComplete() {}
         })
+    }
+
+    private CompletableFuture<byte[]> captureBody(UploadRequest req) {
+        def completed = new CompletableFuture<byte[]>()
+        def output = new ByteArrayOutputStream()
+        req.requestBody().subscribe(new Subscriber<java.nio.ByteBuffer>() {
+            @Override void onSubscribe(Subscription subscription) { subscription.request(Long.MAX_VALUE) }
+            @Override void onNext(java.nio.ByteBuffer buffer) {
+                def bytes = new byte[buffer.remaining()]
+                buffer.get(bytes)
+                output.write(bytes)
+            }
+            @Override void onError(Throwable error) { completed.completeExceptionally(error) }
+            @Override void onComplete() { completed.complete(output.toByteArray()) }
+        })
+        return completed
     }
 
     def "store uses PublicRead ACL and public cache when publicRead=true"() {
@@ -214,9 +250,9 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
     def "verifySettings uses small async client for head/put/delete when forceAsync is enabled"() {
         given:
         def smallAsync = Mock(S3AsyncClient)
-        def regularAsync = Mock(S3AsyncClient)
+        def downloadAsync = Mock(S3AsyncClient)
         def client = Mock(S3Client)
-        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockDownloadAsyncClient: downloadAsync, forceAsync: true)
 
         when:
         def result = ops.verifySettings()
@@ -227,15 +263,15 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
         1 * smallAsync.putObject(_ as Consumer, _) >> CompletableFuture.completedFuture(PutObjectResponse.builder().eTag('etag').build())
         1 * smallAsync.deleteObject(_ as Consumer) >> CompletableFuture.completedFuture(DeleteObjectResponse.builder().build())
         0 * client._
-        0 * regularAsync._
+        0 * downloadAsync._
     }
 
     def "stored uses small async client headObject when forceAsync is enabled"() {
         given:
         def smallAsync = Mock(S3AsyncClient)
-        def regularAsync = Mock(S3AsyncClient)
+        def downloadAsync = Mock(S3AsyncClient)
         def client = Mock(S3Client)
-        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockDownloadAsyncClient: downloadAsync, forceAsync: true)
 
         when:
         def exists = ops.stored('uuid-1')
@@ -244,25 +280,120 @@ class S3StorageOperationsSpec extends Specification implements DataTest {
         exists
         1 * smallAsync.headObject(_ as Consumer) >> CompletableFuture.completedFuture(HeadObjectResponse.builder().build())
         0 * client._
-        0 * regularAsync._
+        0 * downloadAsync._
     }
 
-    def "retrieve still uses main async client when forceAsync is enabled"() {
+    def "retrieve uses the download async client when forceAsync is enabled"() {
         given:
         def smallAsync = Mock(S3AsyncClient)
-        def regularAsync = Mock(S3AsyncClient)
+        def downloadAsync = Mock(S3AsyncClient)
+        def uploadAsync = Mock(S3AsyncClient)
         def client = Mock(S3Client)
         def bytes = 'abc'.bytes
         def responseBytes = ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), bytes)
-        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockAsyncClient: regularAsync, forceAsync: true)
+        def ops = new TestOps(bucket: 'b', prefix: '', mockClient: client, mockSmallAsyncClient: smallAsync, mockDownloadAsyncClient: downloadAsync, mockUploadAsyncClient: uploadAsync, forceAsync: true)
 
         when:
         def actual = ops.retrieve('uuid-2')
 
         then:
         actual == bytes
-        1 * regularAsync.getObject(_ as Consumer, _) >> CompletableFuture.completedFuture(responseBytes)
+        1 * downloadAsync.getObject(_ as Consumer, _) >> CompletableFuture.completedFuture(responseBytes)
         0 * smallAsync.getObject(_, _)
+        0 * uploadAsync._
         0 * client._
+    }
+
+    def "legacy async client override remains the single-client seam for subclasses"() {
+        given:
+        def legacyAsync = Mock(S3AsyncClient)
+        def transferManager = Mock(S3TransferManager)
+        def transferManagerClients = []
+        def ops = new LegacyAsyncClientOps(bucket: 'b', legacyAsyncClient: legacyAsync)
+        ops.setTransferManagerFactoryForTesting({ S3AsyncClient client ->
+            transferManagerClients << client
+            transferManager
+        } as Function<S3AsyncClient, S3TransferManager>)
+
+        when:
+        def smallClient = ops.smallAsyncClient()
+        def downloadClient = ops.downloadAsyncClient()
+        def uploadClient = ops.uploadAsyncClient()
+        def actualTransferManager = ops.getS3TransferManager()
+
+        then:
+        smallClient.is(legacyAsync)
+        downloadClient.is(legacyAsync)
+        uploadClient.is(legacyAsync)
+        actualTransferManager.is(transferManager)
+        transferManagerClients == [legacyAsync]
+    }
+
+    def "close releases the legacy transfer manager without closing the subclass-owned async client"() {
+        given:
+        def legacyAsync = Mock(S3AsyncClient)
+        def transferManager = Mock(S3TransferManager)
+        def ops = new LegacyAsyncClientOps(bucket: 'b', legacyAsyncClient: legacyAsync)
+        ops.setTransferManagerFactoryForTesting({ S3AsyncClient client ->
+            assert client.is(legacyAsync)
+            transferManager
+        } as Function<S3AsyncClient, S3TransferManager>)
+
+        when:
+        ops.getS3TransferManager()
+        ops.close()
+
+        then:
+        1 * transferManager.close()
+        0 * legacyAsync.close()
+    }
+
+    def "migrateTo streams a blocking S3 download into an upload-role transfer manager"() {
+        given:
+        def sourceSmallAsync = Mock(S3AsyncClient)
+        def downloadAsync = Mock(S3AsyncClient)
+        def uploadAsync = Mock(S3AsyncClient)
+        def sourceClient = Mock(S3Client)
+        def destinationClient = Mock(S3Client)
+        def transferManager = Mock(S3TransferManager)
+        def upload = Mock(Upload)
+        def completedUpload = CompletedUpload.builder().response(PutObjectResponse.builder().eTag('etag').build()).build()
+        def source = new TestOps(bucket: 'source-bucket', prefix: '', mockClient: sourceClient, mockSmallAsyncClient: sourceSmallAsync, mockDownloadAsyncClient: downloadAsync, forceAsync: true)
+        def destination = new TestOps(bucket: 'destination-bucket', prefix: '', mockClient: destinationClient, mockUploadAsyncClient: uploadAsync)
+        def uuid = 'uuid-source'
+        def sourceKey = source.createOriginalPathFromUUID(uuid)
+        def object = S3Object.builder().key(sourceKey).size(6L).build()
+        def pages = Mock(ListObjectsV2Publisher)
+        def subscription = Stub(Subscription)
+        CompletableFuture<byte[]> uploadedBody
+        def transferManagerClients = []
+
+        destination.setTransferManagerFactoryForTesting({ S3AsyncClient client ->
+            transferManagerClients << client
+            transferManager
+        } as Function<S3AsyncClient, S3TransferManager>)
+
+        when:
+        source.migrateTo(uuid, 'image/jpeg', destination)
+
+        then:
+        1 * sourceSmallAsync.listObjectsV2Paginator(_ as Consumer) >> pages
+        1 * pages.subscribe(_ as Subscriber) >> { Subscriber<ListObjectsV2Response> subscriber ->
+            subscriber.onSubscribe(subscription)
+            subscriber.onNext(ListObjectsV2Response.builder().contents([object]).build())
+            subscriber.onComplete()
+        }
+        1 * sourceSmallAsync.headObject(_ as Consumer) >> CompletableFuture.completedFuture(HeadObjectResponse.builder().contentType('image/jpeg').contentLength(6L).build())
+        1 * downloadAsync.getObject(_ as Consumer, _) >> CompletableFuture.completedFuture(new ResponseInputStream<>(GetObjectResponse.builder().build(), new ByteArrayInputStream('source'.bytes)))
+        1 * transferManager.upload(_ as UploadRequest) >> { UploadRequest request ->
+            uploadedBody = captureBody(request)
+            upload
+        }
+        1 * upload.completionFuture() >> CompletableFuture.completedFuture(completedUpload)
+        transferManagerClients == [uploadAsync]
+        uploadedBody.get() == 'source'.bytes
+        0 * sourceClient._
+        0 * destinationClient._
+        0 * uploadAsync._
     }
 }

--- a/image-service/src/test/groovy/au/org/ala/images/storage/S3ApplicationStreamWatchdogSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/storage/S3ApplicationStreamWatchdogSpec.groovy
@@ -1,0 +1,125 @@
+package au.org.ala.images.storage
+
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.function.LongSupplier
+
+class S3ApplicationStreamWatchdogSpec extends Specification {
+
+    def 'positive progress renews the only scheduled timeout and timeout action wins once'() {
+        given:
+        def clock = new FakeClock()
+        def scheduler = new FakeScheduler(clock)
+        int timeouts = 0
+        def watchdog = new S3ApplicationStreamWatchdog(Duration.ofSeconds(5), clock, scheduler, { timeouts++ } as Runnable)
+
+        when:
+        clock.advanceSeconds(4)
+        watchdog.progressed(3)
+        clock.advanceSeconds(1)
+        scheduler.runDueTasks()
+
+        then:
+        watchdog.state == S3ApplicationStreamWatchdogState.ACTIVE
+        timeouts == 0
+
+        when:
+        clock.advanceSeconds(4)
+        scheduler.runDueTasks()
+        watchdog.completed()
+        scheduler.runDueTasks()
+
+        then:
+        watchdog.state == S3ApplicationStreamWatchdogState.TIMED_OUT
+        timeouts == 1
+    }
+
+    def 'zero progress does not renew and close wins over a queued timeout'() {
+        given:
+        def clock = new FakeClock()
+        def scheduler = new FakeScheduler(clock)
+        int timeouts = 0
+        def watchdog = new S3ApplicationStreamWatchdog(Duration.ofSeconds(5), clock, scheduler, { timeouts++ } as Runnable)
+
+        when:
+        watchdog.progressed(0)
+        watchdog.closed()
+        clock.advanceSeconds(5)
+        scheduler.runDueTasks()
+
+        then:
+        watchdog.state == S3ApplicationStreamWatchdogState.CLOSED
+        timeouts == 0
+    }
+
+    def 'stale expiry callback cannot replace the progress deadline or leak a task after close'() {
+        given:
+        def clock = new FakeClock()
+        def scheduler = new FakeScheduler(clock)
+        def watchdog = new S3ApplicationStreamWatchdog(Duration.ofSeconds(5), clock, scheduler, {} as Runnable)
+        def staleExpiry = scheduler.lastScheduledTask
+
+        when: 'progress replaces the deadline while the cancelled expiry callback is already executing'
+        watchdog.progressed(1)
+        staleExpiry.runnable.run()
+
+        then: 'the stale generation does not schedule a replacement'
+        scheduler.activeTaskCount == 1
+
+        when:
+        watchdog.closed()
+
+        then: 'the terminal state cancels the sole tracked task'
+        watchdog.state == S3ApplicationStreamWatchdogState.CLOSED
+        scheduler.activeTaskCount == 0
+    }
+
+    private static class FakeClock implements LongSupplier {
+        long nanos
+
+        @Override
+        long getAsLong() { nanos }
+
+        void advanceSeconds(long seconds) { nanos += Duration.ofSeconds(seconds).toNanos() }
+    }
+
+    private static class FakeScheduler implements S3ApplicationStreamWatchdogScheduler {
+        private final FakeClock clock
+        private final List<FakeTask> tasks = []
+
+        FakeScheduler(FakeClock clock) { this.clock = clock }
+
+        @Override
+        S3ApplicationStreamWatchdogTask schedule(Runnable runnable, long delayNanos) {
+            def task = new FakeTask(runnable, clock.nanos + delayNanos)
+            tasks << task
+            return task
+        }
+
+        void runDueTasks() {
+            tasks.findAll { !it.cancelled && it.deadlineNanos <= clock.nanos }.each { task ->
+                task.cancelled = true
+                task.runnable.run()
+            }
+        }
+
+        FakeTask getLastScheduledTask() { tasks.last() }
+
+        int getActiveTaskCount() { tasks.count { !it.cancelled } }
+
+        private static class FakeTask implements S3ApplicationStreamWatchdogTask {
+            final Runnable runnable
+            final long deadlineNanos
+            boolean cancelled
+
+            FakeTask(Runnable runnable, long deadlineNanos) {
+                this.runnable = runnable
+                this.deadlineNanos = deadlineNanos
+            }
+
+            @Override
+            void cancel() { cancelled = true }
+        }
+    }
+}

--- a/image-service/src/test/groovy/au/org/ala/images/storage/S3ApplicationWatchdogInputStreamSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/storage/S3ApplicationWatchdogInputStreamSpec.groovy
@@ -1,0 +1,82 @@
+package au.org.ala.images.storage
+
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.core.SdkResponse
+import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.async.SdkPublisher
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class S3ApplicationWatchdogInputStreamSpec extends Specification {
+
+    def 'blocking async transformer read is aborted once and surfaces the application idle timeout'() {
+        given:
+        def transformer = AsyncResponseTransformer.<SdkResponse>toBlockingInputStream()
+        def response = Stub(SdkResponse)
+        def subscription = new BlockingSubscription()
+        def publisher = new SingleSubscriptionPublisher(subscription)
+        def responseFuture = transformer.prepare()
+        transformer.onResponse(response)
+        transformer.onStream(publisher)
+        ResponseInputStream<SdkResponse> responseStream = responseFuture.get(5, TimeUnit.SECONDS)
+        def stream = new S3ApplicationWatchdogInputStream<SdkResponse>(responseStream, Duration.ofMillis(50), 'test object')
+        def readFailure = new AtomicReference<Throwable>()
+        def reader = Thread.start {
+            try {
+                stream.read()
+            } catch (Throwable error) {
+                readFailure.set(error)
+            }
+        }
+
+        expect: 'the named read boundary is waiting on the SDK blocking transformer'
+        subscription.requested.await(5, TimeUnit.SECONDS)
+
+        when:
+        reader.join(5_000)
+
+        then: 'the watchdog abort unblocks within five seconds and maps the winner to the application timeout'
+        !reader.alive
+        subscription.cancelled.await(5, TimeUnit.SECONDS)
+        subscription.cancelCount == 1
+        stream.timedOut
+        readFailure.get() instanceof S3ApplicationStreamIdleTimeoutException
+
+        when: 'terminal cleanup is repeated after the timeout'
+        stream.close()
+
+        then: 'no second abort is scheduled'
+        subscription.cancelCount == 1
+    }
+
+    private static class SingleSubscriptionPublisher implements SdkPublisher<ByteBuffer> {
+        private final Subscription subscription
+
+        SingleSubscriptionPublisher(Subscription subscription) { this.subscription = subscription }
+
+        @Override
+        void subscribe(Subscriber<? super ByteBuffer> subscriber) { subscriber.onSubscribe(subscription) }
+    }
+
+    private static class BlockingSubscription implements Subscription {
+        final CountDownLatch requested = new CountDownLatch(1)
+        final CountDownLatch cancelled = new CountDownLatch(1)
+        volatile int cancelCount
+
+        @Override
+        void request(long count) { requested.countDown() }
+
+        @Override
+        void cancel() {
+            cancelCount++
+            cancelled.countDown()
+        }
+    }
+}

--- a/image-service/src/test/groovy/au/org/ala/images/storage/S3StorageOperationsSafeguardsSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/storage/S3StorageOperationsSafeguardsSpec.groovy
@@ -1,0 +1,136 @@
+package au.org.ala.images.storage
+
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class S3StorageOperationsSafeguardsSpec extends Specification {
+
+    def 'CRT configuration guards accept documented defaults and reject invalid values'() {
+        expect:
+        S3CrtSafeguards.requirePositive('aws.s3.crt.max-concurrency', 32) == 32
+        S3CrtSafeguards.requirePositive('aws.s3.crt.future-completion-threads', 2) == 2
+        S3CrtSafeguards.requirePositive('aws.s3.crt.future-completion-queue-capacity', 256) == 256
+        S3CrtSafeguards.requireNonNegative('aws.s3.crt.event-loop-threads', 0) == 0
+
+        when:
+        S3CrtSafeguards.requirePositive(property, value)
+
+        then:
+        def error = thrown(IllegalArgumentException)
+        error.message == "${property} must be a positive integer"
+
+        where:
+        property                                          | value
+        'aws.s3.crt.max-concurrency'                      | -1
+        'aws.s3.crt.future-completion-threads'            | 0
+        'aws.s3.crt.future-completion-queue-capacity'     | -1
+    }
+
+    def 'event-loop bootstrap does not mutate CRT state for no-op or late initialization'() {
+        given:
+        def invocations = new AtomicInteger()
+        def setStaticDefault = { invocations.incrementAndGet() } as Runnable
+
+        expect:
+        !S3CrtSafeguards.applyBootstrapIfEligible(0, false, setStaticDefault)
+        !S3CrtSafeguards.applyBootstrapIfEligible(2, true, setStaticDefault)
+        invocations.get() == 0
+
+        when:
+        def initialized = S3CrtSafeguards.applyBootstrapIfEligible(2, false, setStaticDefault)
+
+        then:
+        initialized
+        invocations.get() == 1
+    }
+
+    def 'configured event-loop bootstrap gives Grails YAML precedence and passes its value to the setter'() {
+        given:
+        def configuredThreads = new AtomicInteger()
+
+        when:
+        def resolvedThreads = S3CrtSafeguards.resolveConfiguredEventLoopThreads(
+                { String property -> property == 'aws.s3.crt.event-loop-threads' ? 7 : null },
+                { -> 3 })
+        def initialized = S3CrtSafeguards.applyConfiguredBootstrap({ -> resolvedThreads }, false,
+                { int value -> configuredThreads.set(value) } as java.util.function.IntConsumer)
+
+        then:
+        initialized
+        configuredThreads.get() == 7
+    }
+
+    def 'event-loop resolution rejects negative Grails configuration before CRT construction'() {
+        when:
+        S3CrtSafeguards.resolveConfiguredEventLoopThreads(
+                { String ignored -> -1 },
+                { -> 0 })
+
+        then:
+        def error = thrown(IllegalArgumentException)
+        error.message == 'aws.s3.crt.event-loop-threads must be zero or a positive integer'
+    }
+
+    def 'CRT completion executor rejects saturation and is only closed by its owner'() {
+        given:
+        ThreadPoolExecutor executor = S3CrtSafeguards.newCompletionExecutor(1, 1)
+        def running = new CountDownLatch(1)
+        def release = new CountDownLatch(1)
+        executor.execute {
+            running.countDown()
+            release.await()
+        }
+        assert running.await(5, TimeUnit.SECONDS)
+        executor.execute({ } as Runnable)
+
+        when:
+        executor.execute({ } as Runnable)
+
+        then:
+        thrown(RejectedExecutionException)
+        !executor.shutdown
+
+        cleanup:
+        release?.countDown()
+        executor?.shutdownNow()
+    }
+
+    def 'cache eviction closes only its resource and leaves completion executor available'() {
+        given:
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor()
+        ThreadPoolExecutor completionExecutor = S3CrtSafeguards.newCompletionExecutor(1, 1)
+        def closed = new AtomicBoolean()
+
+        when:
+        S3CrtSafeguards.scheduleEvictedResourceClose({ closed.set(true) } as AutoCloseable, scheduler, 0, TimeUnit.MILLISECONDS)
+        scheduler.shutdown()
+
+        then:
+        scheduler.awaitTermination(5, TimeUnit.SECONDS)
+        closed.get()
+        !completionExecutor.shutdown
+
+        cleanup:
+        scheduler?.shutdownNow()
+        completionExecutor?.shutdownNow()
+    }
+
+    def 'CRT max concurrency is applied through the builder configuration seam'() {
+        given:
+        def configuredConcurrency = new AtomicInteger()
+
+        when:
+        S3CrtSafeguards.configureMaxConcurrency(17, { int value -> configuredConcurrency.set(value) })
+
+        then:
+        configuredConcurrency.get() == 17
+    }
+}


### PR DESCRIPTION
- Split upload and download clients to work around potentital S3 CRT issues
- Add client side watchdog for S3 streams that detects stalls and cancels/aborts job
- Bump AWS SDK and SDK CRT versions