### PR TITLE
Add front end timeouts for cache lookups

### DIFF
--- a/image-service/grails-app/conf/application.yml
+++ b/image-service/grails-app/conf/application.yml
@@ -381,6 +381,12 @@ placeholder:
     missing:
         thumbnail: "classpath:images/200px-Document_icon.svg.png"
 
+derivative:
+    loader:
+        threads: 4
+        queueCapacity: 100
+        timeoutSeconds: 30
+
 openapi:
     title: Image Service API
     description: API Documentation for Image Services

--- a/image-service/grails-app/controllers/au/org/ala/images/ImageController.groovy
+++ b/image-service/grails-app/controllers/au/org/ala/images/ImageController.groovy
@@ -28,11 +28,13 @@ import static io.swagger.v3.oas.annotations.enums.ParameterIn.PATH
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST
 import static javax.servlet.http.HttpServletResponse.SC_FOUND
+import static javax.servlet.http.HttpServletResponse.SC_GATEWAY_TIMEOUT
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND
 import static javax.servlet.http.HttpServletResponse.SC_NOT_MODIFIED
 import static javax.servlet.http.HttpServletResponse.SC_OK
 import static javax.servlet.http.HttpServletResponse.SC_PARTIAL_CONTENT
 import static javax.servlet.http.HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE
 
 @Slf4j
 class ImageController implements MetricsSupport {
@@ -180,12 +182,9 @@ class ImageController implements MetricsSupport {
     def proxyImageThumbnail() {
         boolean invalidate = params.containsKey('i')
         boolean noRedirect = params.containsKey('nr')
-        serveImage(
-                imageStoreService.thumbnailImageInfo(imageService.getImageGUIDFromParams(params), '', invalidate),
-                trackThumbnails,
-                'thumbnail',
-                noRedirect
-        )
+        serveDerivativeImage('thumbnail', trackThumbnails, noRedirect) {
+            imageStoreService.thumbnailImageInfo(imageService.getImageGUIDFromParams(params), '', invalidate)
+        }
     }
 
     @Operation(
@@ -221,12 +220,9 @@ class ImageController implements MetricsSupport {
             render(text: "Invalid thumbnail type", status: SC_NOT_FOUND, contentType: 'text/plain')
             return
         }
-        serveImage(
-                imageStoreService.thumbnailImageInfo(imageService.getImageGUIDFromParams(params), type, invalidate),
-                trackThumbnails,
-                'thumbnail-'+type,
-                noRedirect
-        )
+        serveDerivativeImage('thumbnail-'+type, trackThumbnails, noRedirect) {
+            imageStoreService.thumbnailImageInfo(imageService.getImageGUIDFromParams(params), type, invalidate)
+        }
     }
 
     @Operation(
@@ -262,19 +258,34 @@ class ImageController implements MetricsSupport {
         int z = params.int('z')
         boolean invalidate = params.containsKey('i')
         boolean noRedirect = params.containsKey('nr')
-        serveImage(
-                imageStoreService.tileImageInfo(imageService.getImageGUIDFromParams(params), x, y, z, invalidate),
-                false,
-                'tile',
-                noRedirect
-        )
+        serveDerivativeImage('tile', false, noRedirect) {
+            imageStoreService.tileImageInfo(imageService.getImageGUIDFromParams(params), x, y, z, invalidate)
+        }
+    }
+
+    private void serveDerivativeImage(String requestType, boolean sendAnalytics, boolean noRedirect, Closure<ImageInfo> loadImageInfo) {
+        try {
+            serveImage(loadImageInfo.call(), sendAnalytics, requestType, noRedirect)
+        } catch (ImageStoreService.DerivativeLoadTimeout e) {
+            serveDerivativeUnavailableImage(requestType, SC_GATEWAY_TIMEOUT)
+        } catch (ImageStoreService.DerivativeLoadRejected e) {
+            serveDerivativeUnavailableImage(requestType, SC_SERVICE_UNAVAILABLE)
+        } catch (ImageStoreService.GenerateDerivativeTimeout e) {
+            serveDerivativeUnavailableImage(requestType, SC_SERVICE_UNAVAILABLE)
+        }
+    }
+
+    private void serveDerivativeUnavailableImage(String requestType, int status) {
+        sendMissingImage(requestType, status, true)
     }
 
     private void serveImage(
             ImageInfo imageInfo,
             boolean sendAnalytics,
             String requestType,
-            boolean noRedirect = false) {
+            boolean noRedirect = false,
+            boolean noCache = false,
+            Integer responseStatus = null) {
         recordTime('image.serve', 'Time to serve image request', [type: requestType]) {
             def imageIdentifier = imageInfo.imageIdentifier
             if (!imageIdentifier || !imageInfo.exists) {
@@ -321,7 +332,7 @@ class ImageController implements MetricsSupport {
             // the generate closure
             def etag = imageInfo.etag
             def lastMod = imageInfo.lastModified
-            if (!disableCache) {
+            if (!disableCache && !noCache) {
                 def changed = checkForNotModified(etag, lastMod)
                 if (changed) {
                     if (etag) {
@@ -339,13 +350,13 @@ class ImageController implements MetricsSupport {
             }
 
             length = imageInfo.length
-            def ranges = decodeRangeHeader(length)
+            def ranges = noCache ? [Range.emptyRange(length)] : decodeRangeHeader(length)
             def contentType = imageInfo.contentType
             def extension = imageInfo.extension
 
             if (ranges.size() > 1) {
                 def boundary = startMultipartResponse(ranges, contentType)
-                applyCacheHeaders(disableCache, cacheHeaders, etag, lastMod)
+                applyCacheHeaders(disableCache || noCache, cacheHeaders, etag, lastMod)
 
                 // Grails will provide a dummy output stream for HEAD requests but
                 // explicitly bail on HEAD methods so we don't transfer bytes out of storage
@@ -372,9 +383,12 @@ class ImageController implements MetricsSupport {
                 } else {
                     response.setHeader("Accept-Ranges", "bytes")
                 }
-                applyCacheHeaders(disableCache, cacheHeaders, etag, lastMod)
+                applyCacheHeaders(disableCache || noCache, cacheHeaders, etag, lastMod)
                 response.contentLengthLong = rangeLength
                 response.contentType = contentType
+                if (responseStatus != null) {
+                    response.status = responseStatus
+                }
                 if (contentDisposition) {
                     response.setHeader("Content-disposition", "attachment;filename=${imageIdentifier}.${extension ?: "jpg"}")
                 }
@@ -442,7 +456,7 @@ class ImageController implements MetricsSupport {
      * Serve a placeholder image with a 404 status code.
      * @param requestType The type of request, one of 'tile', 'original', 'thumbnail-large', 'thumbnail-square', 'thumbnail'
      */
-    private void sendMissingImage(String requestType) {
+    private void sendMissingImage(String requestType, int status = SC_NOT_FOUND, boolean noCache = false) {
         Resource ph
         switch (requestType) {
             case 'tile':
@@ -470,9 +484,14 @@ class ImageController implements MetricsSupport {
                 ph = missingImageThumbnail
                 break
         }
+        response.status = status
         try {
+            if (noCache) {
+                response.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
+                response.setHeader('Pragma', 'no-cache')
+                response.setDateHeader('Expires', 0)
+            }
             def len = ph.contentLength()
-            response.status = SC_NOT_FOUND
             response.contentType = 'image/png'
             response.contentLengthLong = len
             if (request.method != 'HEAD') {
@@ -482,7 +501,7 @@ class ImageController implements MetricsSupport {
             }
         } catch (Exception e) {
             log.warn("Failed to stream placeholder image for requestType=${requestType}", e)
-            render(text: "Image not found", status: SC_NOT_FOUND, contentType: 'text/plain')
+            render(text: "Image not found", status: status, contentType: 'text/plain')
         }
     }
 
@@ -902,4 +921,3 @@ class ImageController implements MetricsSupport {
         }
     }
 }
-

--- a/image-service/grails-app/init/au/org/ala/images/Application.groovy
+++ b/image-service/grails-app/init/au/org/ala/images/Application.groovy
@@ -97,6 +97,12 @@ class Application extends GrailsAutoConfiguration {
     @Value('${imageservice.tiling.io.virtualTaskConcurrencyLimitLocal:${tiling.ioVirtualTaskConcurrencyLimitLocal:32}}')
     int tilingIoVirtualTaskConcurrencyLimitLocal
 
+    @Value('${derivative.loader.threads:4}')
+    int derivativeLoaderThreads
+
+    @Value('${derivative.loader.queueCapacity:100}')
+    int derivativeLoaderQueueCapacity
+
     @Bean
     TaskExecutor analyticsExecutor() {
         return createThreadPoolTaskExecutor("analytics-", 1)
@@ -105,6 +111,11 @@ class Application extends GrailsAutoConfiguration {
     @Bean
     TaskExecutor storageLocationExecutor() {
         return createThreadPoolTaskExecutor("storage-", 1)
+    }
+
+    @Bean
+    TaskExecutor derivativeLoaderExecutor() {
+        return createThreadPoolTaskExecutor("derivative-loader-", derivativeLoaderThreads, derivativeLoaderThreads, Math.max(0, derivativeLoaderQueueCapacity))
     }
 
     @Bean

--- a/image-service/grails-app/services/au/org/ala/images/ImageStoreService.groovy
+++ b/image-service/grails-app/services/au/org/ala/images/ImageStoreService.groovy
@@ -52,8 +52,11 @@ import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.function.BiFunction
 import java.util.function.Consumer
 
@@ -109,6 +112,12 @@ class ImageStoreService implements MetricsSupport {
     @Value('${tiling.concurrency.timeout:30}')
     int tileConcurrencyTimeout = 30
 
+    @Value('${derivative.loader.timeoutSeconds:30}')
+    int derivativeLoadTimeoutSeconds = 30
+
+    @Autowired @Qualifier('derivativeLoaderExecutor')
+    Executor derivativeLoaderExecutor
+
     @Value('${images.disableCache:false}')
     boolean disableCache = false
 
@@ -137,8 +146,8 @@ class ImageStoreService implements MetricsSupport {
     @PostConstruct
     @NotTransactional
     def init() {
-        thumbnailCache = Caffeine.from(thumbnailLookupCacheConfig).buildAsync()
-        tileCache = Caffeine.from(tileLookupCacheConfig).buildAsync()
+        thumbnailCache = Caffeine.from(thumbnailLookupCacheConfig).executor(derivativeLoaderExecutor).buildAsync()
+        tileCache = Caffeine.from(tileLookupCacheConfig).executor(derivativeLoaderExecutor).buildAsync()
         originalCache = Caffeine.from(originalLookupCacheConfig).build()
     }
 
@@ -741,13 +750,13 @@ class ImageStoreService implements MetricsSupport {
         def key = Pair.of(imageIdentifier, type)
         def loader = this.&ensureThumbnailExistsCacheLoader.curry(dataResourceUid).curry(operations)
         BiFunction<Pair<String, String>, Executor, CompletableFuture<ImageInfo>> mappingFunction =
-                { Pair<String, String> k, Executor exec -> CompletableFuture.supplyAsync({ loader.call(k) as ImageInfo }, exec) } as BiFunction<Pair<String, String>, Executor, CompletableFuture<ImageInfo>>
+                { Pair<String, String> k, Executor exec -> submitDerivativeLoad(loader, k, exec) } as BiFunction<Pair<String, String>, Executor, CompletableFuture<ImageInfo>>
 
         // TODO undefined behaviour if already loading when invalidate is called.
         if (refresh) {
             thumbnailCache.synchronous().invalidate(key)
         }
-        return (disableCache ? loader.call(key) : thumbnailCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: imageIdentifier, contentType: type == 'square' ? 'image/png' : 'image/jpeg', shouldExist: true)
+        return (disableCache ? loader.call(key) : awaitDerivativeLoad(thumbnailCache, key, mappingFunction)) ?: new ImageInfo(exists: false, imageIdentifier: imageIdentifier, contentType: type == 'square' ? 'image/png' : 'image/jpeg', shouldExist: true)
     }
 
     private ImageInfo ensureThumbnailExistsCacheLoader(String dataResourceUid, StorageOperations operations, Pair<String, String> pair) {
@@ -808,6 +817,9 @@ class ImageStoreService implements MetricsSupport {
             log.warn("Attempted to generate thumbnail for non-image content: ${e.message}")
             incrementCounter('imagestore.thumbnail.notanimage', 'Thumbnail generation skipped - not an image', [mimeType: e.actualMimeType])
             return null // don't cache this error
+        } catch (GenerateDerivativeTimeout e) {
+            // A saturated generator is a request-level availability failure, not a missing thumbnail.
+            throw e
         } catch (e) {
             def rootCause = ExceptionUtils.getRootCause(e)
             if (rootCause instanceof FileNotFoundException) {
@@ -836,7 +848,7 @@ class ImageStoreService implements MetricsSupport {
 
         def loader = this.&ensureTileExistsCacheLoader.curry(zoomLevels).curry(operations)
         BiFunction<Pair<String, Point>, Executor, CompletableFuture<ImageInfo>> mappingFunction =
-                { Pair<String, Point> k, Executor exec -> CompletableFuture.supplyAsync({ loader.call(k) as ImageInfo }, exec) } as BiFunction<Pair<String, Point>, Executor, CompletableFuture<ImageInfo>>
+                { Pair<String, Point> k, Executor exec -> submitDerivativeLoad(loader, k, exec) } as BiFunction<Pair<String, Point>, Executor, CompletableFuture<ImageInfo>>
         def originKey = Pair.of(identifier, new Point(0,0,z))
         def key = Pair.of(identifier, new Point(x, y, z))
 
@@ -851,14 +863,14 @@ class ImageStoreService implements MetricsSupport {
 
         if (onDemandTilingEnabled) {
             // experimental: With on-demand tiling, attempt to fetch/generate exactly the requested tile
-            def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png')
+            def tileInfo = (disableCache ? loader.call(key) : awaitDerivativeLoad(tileCache, key, mappingFunction)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png')
             tileInfo.dataResourceUid = dataResourceUid
             return tileInfo
         } else {
             // Regular behaviour:
             // First check the origin tile for the zoom level, if it doesn't exist then we can generate
             // the whole set of tiles for the level
-            def originInfo = (disableCache ? loader.call(originKey) : tileCache.get(originKey, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: true, contentType: 'image/png')
+            def originInfo = (disableCache ? loader.call(originKey) : awaitDerivativeLoad(tileCache, originKey, mappingFunction)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: true, contentType: 'image/png')
 
             // then if the origin was requested, return the origin info
             // or if the origin doesn't exist then any tile for the given zoom level won't exist either
@@ -868,7 +880,7 @@ class ImageStoreService implements MetricsSupport {
                 return originInfo
             } else {
                 // otherwise now we get the info for the tile that was actually requested and cache it
-                def tileInfo = (disableCache ? loader.call(key) : tileCache.get(key, mappingFunction).join()) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png') // shouldExist is actually unknown here because we don't know the tile bounds
+                def tileInfo = (disableCache ? loader.call(key) : awaitDerivativeLoad(tileCache, key, mappingFunction)) ?: new ImageInfo(exists: false, imageIdentifier: identifier, shouldExist: false, contentType: 'image/png') // shouldExist is actually unknown here because we don't know the tile bounds
                 tileInfo.dataResourceUid = dataResourceUid
                 return tileInfo
             }
@@ -901,6 +913,9 @@ class ImageStoreService implements MetricsSupport {
                             incrementCounter('imagestore.tile.ondemand.failure', 'Failed on-demand tile generations', [reason: result.status.name()])
                             return null // TODO should we cache an IO error?
                         }
+                    } catch (GenerateDerivativeTimeout e) {
+                        // Preserve generator saturation so the request can return a controlled 503.
+                        throw e
                     } catch (Exception e) {
                         incrementCounter('imagestore.tile.ondemand.error', 'On-demand tile generation errors', [error: e.class.simpleName])
                         log.error("Error generating on-demand tile for image ${imageIdentifier} with co-ordinates x:${x}, y:${y}, z:${z}", e)
@@ -915,6 +930,9 @@ class ImageStoreService implements MetricsSupport {
                 }
             }
             return info
+        } catch (GenerateDerivativeTimeout e) {
+            // A saturated generator is a request-level availability failure, not a missing tile.
+            throw e
         } catch (e) {
             def rootCause = ExceptionUtils.getRootCause(e)
             if (rootCause instanceof FileNotFoundException) {
@@ -1202,6 +1220,56 @@ class ImageStoreService implements MetricsSupport {
     static final class GenerateDerivativeTimeout extends RuntimeException {
         GenerateDerivativeTimeout(String message) {
             super(message, null, false, false)
+        }
+    }
+
+    static final class DerivativeLoadTimeout extends RuntimeException {
+        DerivativeLoadTimeout(String message) {
+            super(message, null, false, false)
+        }
+    }
+
+    static final class DerivativeLoadRejected extends RuntimeException {
+        DerivativeLoadRejected(String message, Throwable cause = null) {
+            super(message, cause, false, false)
+        }
+    }
+
+    private CompletableFuture<ImageInfo> submitDerivativeLoad(Closure<ImageInfo> loader, Object key, Executor executor) {
+        try {
+            return CompletableFuture.supplyAsync({ loader.call(key) }, executor)
+        } catch (RejectedExecutionException e) {
+            CompletableFuture<ImageInfo> rejectedLoad = new CompletableFuture<>()
+            rejectedLoad.completeExceptionally(e)
+            return rejectedLoad
+        }
+    }
+
+    private <K> ImageInfo awaitDerivativeLoad(AsyncCache<K, ImageInfo> cache, K key, BiFunction<K, Executor, CompletableFuture<ImageInfo>> mappingFunction) {
+        CompletableFuture<ImageInfo> future
+        try {
+            future = cache.get(key, mappingFunction)
+        } catch (RejectedExecutionException e) {
+            throw new DerivativeLoadRejected("Derivative loader is overloaded for ${key}", e)
+        }
+
+        try {
+            return future.get(derivativeLoadTimeoutSeconds, TimeUnit.SECONDS)
+        } catch (TimeoutException e) {
+            cache.asMap().remove(key, future)
+            throw new DerivativeLoadTimeout("Timed out waiting ${derivativeLoadTimeoutSeconds}s for derivative loader result for ${key}")
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt()
+            throw new IllegalStateException("Interrupted while waiting for derivative loader result for ${key}", e)
+        } catch (ExecutionException e) {
+            Throwable cause = e.cause
+            if (cause instanceof RejectedExecutionException || cause instanceof DerivativeLoadRejected) {
+                throw new DerivativeLoadRejected("Derivative loader is overloaded for ${key}", cause)
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause
+            }
+            throw new IllegalStateException("Derivative loader failed for ${key}", cause)
         }
     }
 }

--- a/image-service/src/test/groovy/au/org/ala/images/ImageControllerSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/ImageControllerSpec.groovy
@@ -13,6 +13,7 @@ import org.grails.web.util.GrailsApplicationAttributes
 import org.grails.web.util.WebUtils
 import org.jasig.cas.client.authentication.AttributePrincipalImpl
 import org.springframework.core.io.ClassPathResource
+import org.springframework.core.io.Resource
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -237,6 +238,81 @@ class ImageControllerSpec extends Specification implements ControllerUnitTest<Im
         0  | 0  | 0  | 'image/jpeg'  | 'bytes=1-2,3-4' | 206         | "multipart/byteranges; boundary=00000000000000000001" | 202 | null | null | fileContent
         0  | 0  | 0  | 'audio/mpeg'  | ''              | 404         | 'text/plain;charset=utf-8' | 0       | null  | null          | new byte[0]
         0  | 0  | 0  | 'application/pdf'  | ''         | 404         | 'text/plain;charset=utf-8' | 0       | null  | null          | new byte[0]
+    }
+
+    @Unroll
+    def "derivative loader #failure renders the #requestType placeholder with #status status"(RuntimeException failure, int status, String requestType, boolean headRequest) {
+        given:
+        String identifier = UUID.randomUUID().toString()
+        ClassPathResource placeholderResource = requestType == 'tile'
+                ? new ClassPathResource('images/images-placeholder-300x300.png')
+                : new ClassPathResource('images/no-image-thumbnail.png')
+        byte[] placeholder = placeholderResource.inputStream.bytes
+        params.id = identifier
+        controller.imageStoreService = Mock(ImageStoreService)
+        controller.analyticsService = Mock(AnalyticsService)
+        if (requestType == 'tile') {
+            params.x = 1
+            params.y = 2
+            params.z = 3
+            controller.missingTile = placeholderResource
+        } else {
+            controller.missingImageThumbnail = placeholderResource
+        }
+        if (headRequest) {
+            request.method = 'HEAD'
+        }
+
+        when:
+        if (requestType == 'tile') {
+            controller.proxyImageTile()
+        } else {
+            controller.proxyImageThumbnail()
+        }
+
+        then:
+        if (requestType == 'tile') {
+            1 * controller.imageStoreService.tileImageInfo(identifier, 1, 2, 3, _) >> { throw failure }
+        } else {
+            1 * controller.imageStoreService.thumbnailImageInfo(identifier, '', _) >> { throw failure }
+        }
+        response.status == status
+        response.contentType == 'image/png'
+        response.contentAsByteArray == (headRequest ? new byte[0] : placeholder)
+        response.getHeader('Cache-Control') == 'no-store, no-cache, must-revalidate'
+        response.getHeader('Pragma') == 'no-cache'
+        response.getDateHeader('Expires') == 0
+        0 * controller.analyticsService._
+
+        where:
+        failure                                                               | status | requestType  | headRequest
+        new ImageStoreService.DerivativeLoadTimeout('timed out')              | 504    | 'thumbnail' | false
+        new ImageStoreService.DerivativeLoadRejected('overloaded')            | 503    | 'tile'      | false
+        new ImageStoreService.GenerateDerivativeTimeout('generator saturated') | 503    | 'thumbnail' | true
+    }
+
+    def "derivative timeout keeps gateway timeout when placeholder metadata fails"() {
+        given:
+        String identifier = UUID.randomUUID().toString()
+        params.id = identifier
+        controller.imageStoreService = Mock(ImageStoreService)
+        controller.missingImageThumbnail = Stub(Resource) {
+            contentLength() >> { throw new IOException('placeholder metadata unavailable') }
+        }
+
+        when:
+        controller.proxyImageThumbnail()
+
+        then:
+        1 * controller.imageStoreService.thumbnailImageInfo(identifier, '', _) >> {
+            throw new ImageStoreService.DerivativeLoadTimeout('timed out')
+        }
+        response.status == 504
+        response.contentType == 'text/plain;charset=utf-8'
+        response.text == 'Image not found'
+        response.getHeader('Cache-Control') == 'no-store, no-cache, must-revalidate'
+        response.getHeader('Pragma') == 'no-cache'
+        response.getDateHeader('Expires') == 0
     }
 
     def "test text/html details"() {

--- a/image-service/src/test/groovy/au/org/ala/images/ImageStoreServiceSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/ImageStoreServiceSpec.groovy
@@ -5,16 +5,23 @@ import au.org.ala.images.thumb.IImageThumbnailer
 import au.org.ala.images.tiling.IImageTiler
 import au.org.ala.images.tiling.IOnDemandImageTiler
 import com.google.common.io.Resources
+import org.apache.commons.lang3.tuple.Pair
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.grails.plugins.testing.GrailsMockMultipartFile
 import spock.lang.Specification
 
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BiFunction
 
 class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<ImageStoreService>, DataTest {
 
@@ -26,6 +33,7 @@ class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<Ima
         applicationContext.registerBean("imageThumbnailer", IImageThumbnailer, { -> imageThumbnailer })
         applicationContext.registerBean("imageTiler", IImageTiler, { -> imageTiler })
         applicationContext.registerBean("onDemandImageTiler", IOnDemandImageTiler, { -> onDemandImageTiler })
+        applicationContext.registerBean("derivativeLoaderExecutor", Executor, { -> { Runnable task -> task.run() } as Executor })
 
         service.auditService = Mock(AuditService)
         service.storageLocationService = Mock(StorageLocationService)
@@ -68,13 +76,17 @@ class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<Ima
 
     def "thumbnailImageInfo coalesces concurrent loads for same key when cache is enabled"() {
         given:
+        ExecutorService derivativeExecutor = Executors.newSingleThreadExecutor({ Runnable runnable -> new Thread(runnable, 'derivative-loader-test-') })
         service.initSemaphores()
+        service.derivativeLoaderExecutor = derivativeExecutor
         service.init()
         service.disableCache = false
         def callCount = new AtomicInteger(0)
+        def loaderThreadName = new AtomicReference<String>()
         def operations = Stub(StorageOperations) {
             thumbnailImageInfo('img-1', '') >> {
                 callCount.incrementAndGet()
+                loaderThreadName.set(Thread.currentThread().name)
                 Thread.sleep(200)
                 new ImageInfo(exists: true, imageIdentifier: 'img-1', contentType: 'image/jpeg', extension: 'jpg', inputStreamSupplier: { r -> new ByteArrayInputStream(new byte[0]) })
             }
@@ -95,9 +107,11 @@ class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<Ima
         r1.exists
         r2.exists
         callCount.get() == 1
+        loaderThreadName.get().startsWith('derivative-loader-test-')
 
         cleanup:
         pool.shutdownNow()
+        derivativeExecutor.shutdownNow()
     }
 
     def "thumbnailImageInfo performs separate loads when cache is disabled"() {
@@ -130,6 +144,84 @@ class ImageStoreServiceSpec extends Specification implements ServiceUnitTest<Ima
 
         cleanup:
         pool.shutdownNow()
+    }
+
+    def "thumbnailImageInfo evicts a timed-out cache future so a later request can retry"() {
+        given:
+        ExecutorService derivativeExecutor = Executors.newSingleThreadExecutor()
+        CountDownLatch firstLoadStarted = new CountDownLatch(1)
+        CountDownLatch allowFirstLoadToFinish = new CountDownLatch(1)
+        AtomicInteger callCount = new AtomicInteger(0)
+        service.initSemaphores()
+        service.derivativeLoaderExecutor = derivativeExecutor
+        service.derivativeLoadTimeoutSeconds = 1
+        service.init()
+        service.disableCache = false
+        def operations = Stub(StorageOperations) {
+            thumbnailImageInfo('img-timeout', '') >> {
+                if (callCount.incrementAndGet() == 1) {
+                    firstLoadStarted.countDown()
+                    allowFirstLoadToFinish.await(5, TimeUnit.SECONDS)
+                }
+                new ImageInfo(exists: true, imageIdentifier: 'img-timeout', contentType: 'image/jpeg', extension: 'jpg', inputStreamSupplier: { r -> new ByteArrayInputStream(new byte[0]) })
+            }
+        }
+        service.storageLocationService.getStorageOperationsWithoutDbLookup() >> operations
+
+        when:
+        service.thumbnailImageInfo('img-timeout', '', false)
+
+        then:
+        firstLoadStarted.await(1, TimeUnit.SECONDS)
+        thrown(ImageStoreService.DerivativeLoadTimeout)
+
+        when:
+        allowFirstLoadToFinish.countDown()
+        def retried = service.thumbnailImageInfo('img-timeout', '', false)
+
+        then:
+        retried.exists
+        callCount.get() == 2
+
+        cleanup:
+        allowFirstLoadToFinish.countDown()
+        derivativeExecutor.shutdownNow()
+    }
+
+    def "thumbnailImageInfo propagates a saturated thumbnail generator"() {
+        given:
+        service.thumbnailConcurrencyLevel = 1
+        service.thumbnailConcurrencyTimeout = 0
+        service.initSemaphores()
+        service.init()
+        service.disableCache = false
+        service.@thumbnailSemaphore.acquire()
+        def operations = Stub(StorageOperations) {
+            thumbnailImageInfo('img-saturated', '') >> new ImageInfo(exists: false, imageIdentifier: 'img-saturated')
+        }
+        service.storageLocationService.getStorageOperationsWithoutDbLookup() >> operations
+
+        when:
+        service.thumbnailImageInfo('img-saturated', '', false)
+
+        then:
+        thrown(ImageStoreService.GenerateDerivativeTimeout)
+
+        cleanup:
+        service.@thumbnailSemaphore.release()
+    }
+
+    def "thumbnailImageInfo reports a rejected derivative loader"() {
+        given:
+        service.initSemaphores()
+        service.init()
+
+        when:
+        service.awaitDerivativeLoad(service.thumbnailCache, Pair.of('img-rejected', ''),
+                { key, executor -> CompletableFuture.failedFuture(new RejectedExecutionException('queue full')) } as BiFunction)
+
+        then:
+        thrown(ImageStoreService.DerivativeLoadRejected)
     }
 
 }


### PR DESCRIPTION
- Dedicated bounded derivative-loader- executor now runs Caffeine thumbnail/tile cache loads instead of ForkJoinPool.commonPool.

- Cache waits have a timeout; timed-out mappings are conditionally evicted so later requests can retry.
- Executor rejection and generation-capacity timeout now reach the controller as controlled 503 responses; dependency/cache-wait timeout returns 504.
- Both responses stream the existing missing image placeholder as a non-cacheable image body.
- Invalid negative queue configuration is clamped so the derivative loader cannot become unbounded.
- Added focused coverage for coalescing, timeout eviction/retry, generation timeout propagation, executor rejection, and controller error response.