### PR TITLE
Fix 'cjpeg' unrecognized input file format errors

### DIFF
--- a/image-service/grails-app/conf/application.yml
+++ b/image-service/grails-app/conf/application.yml
@@ -647,14 +647,8 @@ images:
               - "%OUT%"
       optimAggressive:
         jpeg:
-          - tool: "mozjpeg"
+          - tool: "vipsJpeg"
             lossy: true
-            args:
-              - "-quality"
-              - "75"
-              - "-optimize"
-              - "-progressive"
-              - "%IN%"
         png:
           - tool: "pngquant"
             lossy: true
@@ -693,9 +687,25 @@ images:
       jpegoptim:
         cmd: "jpegoptim"
         inPlace: true
-      mozjpeg:
-        cmd: "cjpeg"
-        stdout: true
+      vipsJpeg:
+        cmd: "vips"
+        inPlace: false
+        fallback: ["convertJpeg"]
+        args:
+          - "copy"
+          - "%IN%"
+          - "%OUT%[Q=75,interlace,strip,optimize_coding]"
+      convertJpeg:
+        cmd: "convert"
+        inPlace: false
+        args:
+          - "%IN%"
+          - "-strip"
+          - "-interlace"
+          - "Plane"
+          - "-quality"
+          - "75"
+          - "%OUT%"
       oxipng:
         cmd: "oxipng"
         inPlace: true

--- a/image-service/grails-app/services/au/org/ala/images/ImageOptimisationService.groovy
+++ b/image-service/grails-app/services/au/org/ala/images/ImageOptimisationService.groovy
@@ -148,7 +148,9 @@ class ImageOptimisationService implements MetricsSupport {
                     boolean acceptLarger = step.acceptLarger
                     boolean alwaysAccept = step.alwaysAccept
 
-                    List<String> confArgs = step.args
+                    List<String> confArgs = []
+                    confArgs.addAll(resolved.args ?: [])
+                    confArgs.addAll(step.args ?: [])
                     File outFile = inPlace ? current : new File(workDir, "${stageName}_step${i}" + (outExt ?: extensionFor(format, current)))
                     Map<String, String> tokens = buildTokens(current, workDir, format, [:], outExt)
                     tokens[TOKEN_OUT] = outFile.absolutePath

--- a/image-service/src/main/groovy/au/org/ala/images/config/ImageOptimisationConfig.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/config/ImageOptimisationConfig.groovy
@@ -67,7 +67,7 @@ class ImageOptimisationConfig {
             ],
             optimAggressive: [
                     jpeg: [
-                            StageStep.lossy('mozjpeg', ['-quality', '75', '-optimize', '-progressive', '%IN%'])
+                            StageStep.lossy('vipsJpeg')
                     ],
                     png: [
                             StageStep.lossy('pngquant', ['--quality=60-80', '--speed=1', '--force', '--output=%OUT%', '%IN%'])
@@ -100,7 +100,15 @@ class ImageOptimisationConfig {
             // JPEG
             jpegtran: Tool.stdout('jpegtran'),
             jpegoptim: Tool.process('jpegoptim', true),
-            mozjpeg: Tool.stdout('cjpeg'),
+            vipsJpeg: new Tool(
+                    cmd: 'vips',
+                    fallback: ['convertJpeg'],
+                    args: ['copy', '%IN%', '%OUT%[Q=75,interlace,strip,optimize_coding]']
+            ),
+            convertJpeg: new Tool(
+                    cmd: 'convert',
+                    args: ['%IN%', '-strip', '-interlace', 'Plane', '-quality', '75', '%OUT%']
+            ),
             // Java SPI example tool
             javaResize: Tool.java(ImageResizeTool),
             // PNG

--- a/image-service/src/main/groovy/au/org/ala/images/config/ImageOptimisationConfigLoader.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/config/ImageOptimisationConfigLoader.groovy
@@ -290,6 +290,13 @@ class ImageOptimisationConfigLoader {
             }
         }
 
+        if (map.containsKey('args')) {
+            def args = map.get('args')
+            if (args instanceof List) {
+                tool.args = args.collect { it.toString() }
+            }
+        }
+
         return tool
     }
 
@@ -340,4 +347,3 @@ class ImageOptimisationConfigLoader {
         return null
     }
 }
-

--- a/image-service/src/main/groovy/au/org/ala/images/config/Tool.groovy
+++ b/image-service/src/main/groovy/au/org/ala/images/config/Tool.groovy
@@ -10,6 +10,7 @@ class Tool {
     boolean inPlace = false
     boolean stdout = false  // true if tool writes output to stdout instead of a file
     List<String> fallback = []
+    List<String> args = []
     // For Java tools
     String className // using 'className' to avoid conflict with Class
 

--- a/image-service/src/test/groovy/au/org/ala/images/ToolConfigurationSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/ToolConfigurationSpec.groovy
@@ -16,8 +16,7 @@ class ToolConfigurationSpec extends Specification {
 
         @Override
         boolean isInstalled(String cmd) {
-            System.out.println("[DEBUG_LOG] Checking if installed: ${cmd}")
-            return true
+            return installedTools.isEmpty() || installedTools.contains(cmd)
         }
 
         @Override
@@ -76,8 +75,7 @@ class ToolConfigurationSpec extends Specification {
                 def stage = new Stage(name: 'test', toolsRef: toolsetName, allowLossy: true)
                 config.stages['testPipe'] = [stage]
 
-                def result = service.optimise(f, testFormat, 'testPipe')
-                println "Ran ${toolsetName} for ${format} (type: ${testFormat}), file: ${f.absolutePath}, calls: ${capturer.calls.size()}, warnings: ${result.warnings}"
+                service.optimise(f, testFormat, 'testPipe')
             }
         }
 
@@ -85,7 +83,7 @@ class ToolConfigurationSpec extends Specification {
         noExceptionThrown()
     }
 
-    def "specific check for mozjpeg / cjpeg stdout configuration"() {
+    def "aggressive JPEG optimisation prefers vips and falls back to convert with JPEG input and output"() {
         given:
         def service = new ImageOptimisationService()
         def capturer = new CapturingExec()
@@ -93,10 +91,10 @@ class ToolConfigurationSpec extends Specification {
 
         def config = new ImageOptimisationConfig()
         config.skipThresholdBytes = -1
-        // Ensure mozjpeg is using cjpeg and stdout
-        Tool mozjpeg = config.tools['mozjpeg']
-        assert mozjpeg.cmd == 'cjpeg'
-        assert mozjpeg.stdout == true
+        Tool vipsJpeg = config.tools['vipsJpeg']
+        assert vipsJpeg.cmd == 'vips'
+        assert vipsJpeg.fallback == ['convertJpeg']
+        assert !config.tools.containsKey('mozjpeg')
 
         // Force the pipeline to include our stage
         config.stages['testAggressive'] = [new Stage(name: 'opt', toolsRef: 'optimAggressive', allowLossy: true)]
@@ -106,18 +104,26 @@ class ToolConfigurationSpec extends Specification {
         File f = new File(tempDir, "test.jpg")
         f.text = "test content " * 100
 
-        when:
-        def result = service.optimise(f, 'image/jpeg', 'testAggressive')
+        when: 'libvips is available'
+        capturer.installedTools = ['vips'] as Set
+        service.optimise(f, 'image/jpeg', 'testAggressive')
 
         then:
-        println "Result warnings: ${result.warnings}"
-        println "Calls for mozjpeg: ${capturer.calls}"
-        def call = capturer.calls.find { it.cmd == 'cjpeg' }
-        call != null
-        call.stdout == true
-        // Should NOT have an output file in arguments because it's a stdout tool
-        !call.args.any { it.contains("step") }
-        call.args.any { it.contains("current.jpg") }
+        def vipsCall = capturer.calls.find { it.cmd == 'vips' }
+        vipsCall.args[0] == 'copy'
+        vipsCall.args[1].endsWith('current.jpg')
+        vipsCall.args[2].endsWith('opt_step0.jpg[Q=75,interlace,strip,optimize_coding]')
+
+        when: 'libvips is unavailable'
+        capturer.calls.clear()
+        capturer.installedTools = ['convert'] as Set
+        service.optimise(f, 'image/jpeg', 'testAggressive')
+
+        then:
+        def convertCall = capturer.calls.find { it.cmd == 'convert' }
+        convertCall.args[0].endsWith('current.jpg')
+        convertCall.args.containsAll(['-strip', '-interlace', 'Plane', '-quality', '75'])
+        convertCall.args.last().endsWith('opt_step0.jpg')
     }
 
     def "verify pngquant configuration handles output argument correctly"() {
@@ -142,11 +148,9 @@ class ToolConfigurationSpec extends Specification {
 
         when:
         // Use a pipeline that definitely contains pngquant
-        def result = service.optimise(f, 'image/png', 'testPng')
+        service.optimise(f, 'image/png', 'testPng')
 
         then:
-        println "Result warnings: ${result.warnings}"
-        println "Calls for pngquant: ${capturer.calls}"
         def call = capturer.calls.find { it.cmd == 'pngquant' }
         call != null
         call.stdout == false

--- a/image-service/src/test/groovy/au/org/ala/images/config/ImageOptimisationConfigLoaderSpec.groovy
+++ b/image-service/src/test/groovy/au/org/ala/images/config/ImageOptimisationConfigLoaderSpec.groovy
@@ -53,6 +53,11 @@ class ImageOptimisationConfigLoaderSpec extends Specification implements Autowir
                             type: 'java',
                             className: 'com.example.MyTool'
                     ]
+            config.images.optimisation.tools.vipsJpeg = [
+                            cmd: 'vips',
+                            fallback: ['convertJpeg'],
+                            args: ['copy', '%IN%', '%OUT%[Q=75,interlace,strip,optimize_coding]']
+                    ]
         }
     }
 
@@ -89,6 +94,8 @@ class ImageOptimisationConfigLoaderSpec extends Specification implements Autowir
         imageOptimisationConfig.tools['javaTool'] != null
         imageOptimisationConfig.tools['javaTool'].type == 'java'
         imageOptimisationConfig.tools['javaTool'].className == 'com.example.MyTool'
+        imageOptimisationConfig.tools['vipsJpeg'].fallback == ['convertJpeg']
+        imageOptimisationConfig.tools['vipsJpeg'].args == ['copy', '%IN%', '%OUT%[Q=75,interlace,strip,optimize_coding]']
     }
 
     void "test config loader preserves defaults when no config present"() {
@@ -125,4 +132,3 @@ class ImageOptimisationConfigLoaderSpec extends Specification implements Autowir
         imageOptimisationConfig.tools == originalTools
     }
 }
-


### PR DESCRIPTION
- Replace with libvips tools and imagemagick fallback for jpeg re-encode
- Add tool level support for args
  - Previously a fallback tool required the same argument format as the original tool
  - This might need to evolve into a logical operation abstraction inbetween tool and stages in the future if multiple of the same tool get defined